### PR TITLE
IMethodHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@
 
 ### Admin capabilities
 
-- manage hooks
+- owner can manage hooks
+- `_requireCallerIsContractOwner` - override to set custom rules for ownership.
 
 ### TODO
 
-- fix failing unit tests in Github actions
+- finish setting up `IMethodHooks.sol`
+- calculate gas costs (Minting / Contract Deployment / Transfers) compared to ERC721A
+- Migrate Staking to Hooks
+- Subscription for Hooks ([ERC5643](https://eips.ethereum.org/EIPS/eip-5643))
+- NATSPEC docs (TODOs)
 - ERC721AH
 - ERC721CH
-- initial README
-- `IHookManager.sol`
-- `IHook.sol`
+- update README

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@
 ### TODO
 
 - finish setting up `IMethodHooks.sol`
+- optimize hook setting in `ERC721ACH.sol` (struct?)
 - calculate gas costs (Minting / Contract Deployment / Transfers) compared to ERC721A
-- Migrate Staking to Hooks
+- Migrate Staking (`cre8ing.sol`) to Hooks
 - Subscription for Hooks ([ERC5643](https://eips.ethereum.org/EIPS/eip-5643))
 - NATSPEC docs (TODOs)
-- ERC721AH
-- ERC721CH
+- ERC721H - hooks on pure ERC721
+- ERC721AH - hooks on ERC721A (without ERC721C)
+- ERC721CH - hooks on ERC721C (without ERC721A)
 - update README

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@
 
 ### TODO
 
-- finish setting up `IMethodHooks.sol`
-- optimize hook setting in `ERC721ACH.sol` (struct?)
+- add `before` & `after` hooks to ANY write methods.
+- add hooks for any missing functions in ERC721A.
+- add hooks for any missing functions in ERC721C.
+- optimize hook storage in `ERC721ACH.sol` (struct?)
 - calculate gas costs (Minting / Contract Deployment / Transfers) compared to ERC721A
 - Migrate Staking (`cre8ing.sol`) to Hooks
 - Subscription for Hooks ([ERC5643](https://eips.ethereum.org/EIPS/eip-5643))

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -301,16 +301,19 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     /// ERC721H Admin Controls
     /////////////////////////////////////////////////
 
+    /// TODO
     function setBalanceOfHook(IBalanceOfHook _hook) external virtual onlyOwner {
         balanceOfHook = _hook;
         emit UpdatedHookBalanceOf(msg.sender, address(_hook));
     }
 
+    /// TODO
     function setOwnerOfHook(IOwnerOfHook _hook) external virtual onlyOwner {
         ownerOfHook = _hook;
         emit UpdatedHookOwnerOf(msg.sender, address(_hook));
     }
 
+    /// TODO
     function setSafeTransferFromHook(
         ISafeTransferFromHook _hook
     ) external virtual onlyOwner {
@@ -318,6 +321,7 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
         emit UpdatedHookSafeTransferFrom(msg.sender, address(_hook));
     }
 
+    /// TODO
     modifier onlyOwner() {
         _requireCallerIsContractOwner();
 

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -157,6 +157,25 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
         uint256 tokenId,
         bytes memory data
     ) public payable virtual override {
+        _safeTransferFrom(from, to, tokenId, data);
+    }
+
+    /// @inheritdoc IERC721A
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public payable virtual override {
+        _safeTransferFrom(from, to, tokenId, "");
+    }
+
+    /// TODO
+    function _safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) internal {
         if (
             address(safeTransferFromHook) != address(0) &&
             safeTransferFromHook.useSafeTransferFromHook(
@@ -176,34 +195,6 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
             );
         } else {
             super.safeTransferFrom(from, to, tokenId, data);
-        }
-    }
-
-    /// @inheritdoc IERC721A
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 tokenId
-    ) public payable virtual override {
-        if (
-            address(safeTransferFromHook) != address(0) &&
-            safeTransferFromHook.useSafeTransferFromHook(
-                msg.sender,
-                from,
-                to,
-                tokenId,
-                ""
-            )
-        ) {
-            safeTransferFromHook.safeTransferFromOverrideHook(
-                msg.sender,
-                from,
-                to,
-                tokenId,
-                ""
-            );
-        } else {
-            super.safeTransferFrom(from, to, tokenId);
         }
     }
 

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -9,6 +9,7 @@ import {ISafeTransferFromHook} from "./interfaces/ISafeTransferFromHook.sol";
 import {ITransferFromHook} from "./interfaces/ITransferFromHook.sol";
 import {IApproveHook} from "./interfaces/IApproveHook.sol";
 import {ISetApprovalForAllHook} from "./interfaces/ISetApprovalForAllHook.sol";
+import {IGetApprovedHook} from "./interfaces/IGetApprovedHook.sol";
 import {IERC721ACH} from "./interfaces/IERC721ACH.sol";
 
 /**
@@ -24,6 +25,7 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     ITransferFromHook public transferFromHook;
     IApproveHook public approveHook;
     ISetApprovalForAllHook public setApprovalForAllHook;
+    IGetApprovedHook public getApprovedHook;
 
     /// @notice Contract constructor
     /// @param _contractName The name for the token contract
@@ -112,8 +114,11 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     function getApproved(
         uint256 tokenId
     ) public view virtual override returns (address) {
-        if (_useGetApprovedHook(tokenId)) {
-            return _getApprovedHook(tokenId);
+        if (
+            address(getApprovedHook) != address(0) &&
+            getApprovedHook.useGetApprovedHook(tokenId)
+        ) {
+            return getApprovedHook.getApprovedOverrideHook(tokenId);
         }
         return super.getApproved(tokenId);
     }
@@ -197,20 +202,6 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     /// ERC721 Hooks
     /////////////////////////////////////////////////
 
-    /// @notice getApproved Hook for custom implementation.
-    /// @param tokenId The token ID to query the approval of
-    /// @dev Returns the approved address for a token ID, or zero if no address set
-    function _getApprovedHook(
-        uint256 tokenId
-    ) internal view virtual returns (address) {}
-
-    /// @notice Check if the getApproved function should use hook.
-    /// @param tokenId The token ID to query the approval of
-    /// @dev Returns whether or not to use the hook for getApproved function
-    function _useGetApprovedHook(
-        uint256 tokenId
-    ) internal view virtual returns (bool) {}
-
     /// @notice isApprovedForAll Hook for custom implementation.
     /// @param owner The address that owns the NFTs
     /// @param operator The address that acts on behalf of the owner
@@ -280,6 +271,14 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     ) external virtual onlyOwner {
         setApprovalForAllHook = _hook;
         emit UpdatedHookSetApprovalForAll(msg.sender, address(_hook));
+    }
+
+    /// TODO
+    function setGetApprovedHook(
+        IGetApprovedHook _hook
+    ) external virtual onlyOwner {
+        getApprovedHook = _hook;
+        emit UpdatedHookGetApproved(msg.sender, address(_hook));
     }
 
     /// TODO

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -31,16 +31,6 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
         bool approved
     );
 
-    /// @notice Emitted when transferFrom hook is used
-    /// @param from The sender of the token
-    /// @param to The receiver of the token
-    /// @param tokenId The ID of the token
-    event TransferFromHookUsed(
-        address indexed from,
-        address indexed to,
-        uint256 indexed tokenId
-    );
-
     IBalanceOfHook public balanceOfHook;
     IOwnerOfHook public ownerOfHook;
     ISafeTransferFromHook public safeTransferFromHook;

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -312,19 +312,19 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
 
     function setBalanceOfHook(IBalanceOfHook _hook) external virtual onlyOwner {
         balanceOfHook = _hook;
-        emit UpdatedHook_BalanceOf(msg.sender, address(_hook));
+        emit UpdatedHookBalanceOf(msg.sender, address(_hook));
     }
 
     function setOwnerOfHook(IOwnerOfHook _hook) external virtual onlyOwner {
         ownerOfHook = _hook;
-        emit UpdatedHook_OwnerOf(msg.sender, address(_hook));
+        emit UpdatedHookOwnerOf(msg.sender, address(_hook));
     }
 
     function setSafeTransferFromHook(
         ISafeTransferFromHook _hook
     ) external virtual onlyOwner {
         safeTransferFromHook = _hook;
-        emit UpdatedHook_SafeTransferFrom(msg.sender, address(_hook));
+        emit UpdatedHookSafeTransferFrom(msg.sender, address(_hook));
     }
 
     modifier onlyOwner() {

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -98,7 +98,11 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
                 approved
             )
         ) {
-            _setApprovalForAllHook(msg.sender, operator, approved);
+            setApprovalForAllHook.setApprovalForAllOverrideHook(
+                msg.sender,
+                operator,
+                approved
+            );
         } else {
             super.setApprovalForAll(operator, approved);
         }
@@ -192,27 +196,6 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     /////////////////////////////////////////////////
     /// ERC721 Hooks
     /////////////////////////////////////////////////
-
-    /// @notice setApprovalForAll Hook for custom implementation.
-    /// @param owner The address to extend operators for
-    /// @param operator The address to add to the set of authorized operators
-    /// @param approved True if the operator is approved, false to revoke approval
-    function _setApprovalForAllHook(
-        address owner,
-        address operator,
-        bool approved
-    ) internal virtual {}
-
-    /// @notice Check if the setApprovalForAll function should use hook.
-    /// @param owner The address to extend operators for
-    /// @param operator The address to add to the set of authorized operators
-    /// @param approved True if the operator is approved, false to revoke approval
-    /// @dev Returns whether or not to use the hook for setApprovalForAll function
-    function _useSetApprovalForAllHook(
-        address owner,
-        address operator,
-        bool approved
-    ) internal view virtual returns (bool) {}
 
     /// @notice getApproved Hook for custom implementation.
     /// @param tokenId The token ID to query the approval of

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -273,27 +273,6 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
         address operator
     ) internal view virtual returns (bool) {}
 
-    /// @notice transferFrom Hook for custom implementation.
-    /// @param from The current owner of the NFT
-    /// @param to The new owner
-    /// @param tokenId The NFT to transfer
-    function _transferFromHook(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual {}
-
-    /// @notice Check if the transferFrom function should use hook.
-    /// @param from The current owner of the NFT
-    /// @param to The new owner
-    /// @param tokenId The NFT to transfer
-    /// @dev Returns whether or not to use the hook for transferFrom function
-    function _useTransferFromHook(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal view virtual returns (bool) {}
-
     /////////////////////////////////////////////////
     /// ERC721C Override
     /////////////////////////////////////////////////

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.15;
 
 import {ERC721AC} from "ERC721C/erc721c/ERC721AC.sol";
 import {IERC721A} from "erc721a/contracts/IERC721A.sol";
+import {IBalanceOfHook} from "./interfaces/IBalanceOfHook.sol";
 
 /**
  * @title ERC721ACH
@@ -49,6 +50,8 @@ contract ERC721ACH is ERC721AC {
         uint256 tokenId,
         bytes data
     );
+
+    IBalanceOfHook public balanceOfHook;
 
     /// @notice Contract constructor
     /// @param _contractName The name for the token contract

--- a/src/interfaces/IApproveHook.sol
+++ b/src/interfaces/IApproveHook.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface IApproveHook {
+    /// @notice Emitted when approve hook is used
+    /// @param approved The address that got approved
+    /// @param tokenId The token ID that got approved
+    event ApproveHookUsed(address indexed approved, uint256 indexed tokenId);
+
+    /// @notice Check if the approve function should use hook.
+    /// @param approved The address to be approved for the given token ID
+    /// @param tokenId The token ID to be approved
+    /// @dev Returns whether or not to use the hook for approve function
+    function useApproveHook(
+        address approved,
+        uint256 tokenId
+    ) external view returns (bool);
+
+    /// @notice approve Hook for custom implementation.
+    /// @param approved The address to be approved for the given token ID
+    /// @param tokenId The token ID to be approved
+    function approveOverrideHook(
+        address approved,
+        uint256 tokenId
+    ) external view returns (uint256);
+}

--- a/src/interfaces/IBalanceOfHook.sol
+++ b/src/interfaces/IBalanceOfHook.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface IBalanceOfHook {}

--- a/src/interfaces/IBalanceOfHook.sol
+++ b/src/interfaces/IBalanceOfHook.sol
@@ -1,4 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-interface IBalanceOfHook {}
+interface IBalanceOfHook {
+    /// @notice Check if the balanceOf function should use hook.
+    /// @param owner The address to query the balance of
+    /// @dev Returns whether or not to use the hook for balanceOf function
+    function useBalanceOfHook(address owner) external view returns (bool);
+
+    /// @notice balanceOf Hook for custom implementation.
+    /// @param owner The address to query the balance of
+    /// @dev Returns the balance of the specified address
+    function balanceOfOverrideHook(
+        address owner
+    ) external view returns (uint256);
+}

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -2,6 +2,9 @@
 pragma solidity ^0.8.15;
 
 interface IERC721ACH {
+    /// @notice error onlyOwner
+    error Access_OnlyOwner();
+
     /// @notice Emitted when balanceOf hook is used
     /// @param caller The caller
     /// @param hook The new hook

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -14,4 +14,12 @@ interface IERC721ACH {
     /// @param caller The caller
     /// @param hook The new hook
     event UpdatedHook_OwnerOf(address indexed caller, address indexed hook);
+
+    /// @notice Emitted when safeTransferFrom hook is set
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHook_SafeTransferFrom(
+        address indexed caller,
+        address indexed hook
+    );
 }

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -48,6 +48,11 @@ interface IERC721ACH {
         address indexed hook
     );
 
+    /// @notice Emitted when getApproved hook is set
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHookGetApproved(address indexed caller, address indexed hook);
+
     /// TODO
     function setBalanceOfHook(IBalanceOfHook _hook) external;
 

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -27,6 +27,11 @@ interface IERC721ACH {
         address indexed hook
     );
 
+    /// @notice Emitted when transferFrom hook is set
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHookTransferFrom(address indexed caller, address indexed hook);
+
     /// TODO
     function setBalanceOfHook(IBalanceOfHook _hook) external;
 

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -11,7 +11,7 @@ interface IERC721ACH {
     /// @notice error onlyOwner
     error Access_OnlyOwner();
 
-    /// @notice Emitted when balanceOf hook is used
+    /// @notice Emitted when balanceOf hook is set
     /// @param caller The caller
     /// @param hook The new hook
     event UpdatedHookBalanceOf(address indexed caller, address indexed hook);

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface IERC721ACH {
+    /// @notice Emitted when balanceOf hook is used
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHook_BalanceOf(address indexed caller, address indexed hook);
+
+    /// @notice Emitted when ownerOf hook is set
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHook_OwnerOf(address indexed caller, address indexed hook);
+}

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -53,6 +53,14 @@ interface IERC721ACH {
     /// @param hook The new hook
     event UpdatedHookGetApproved(address indexed caller, address indexed hook);
 
+    /// @notice Emitted when isApprovedForAll hook is set
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHookIsApprovedForAll(
+        address indexed caller,
+        address indexed hook
+    );
+
     /// TODO
     function setBalanceOfHook(IBalanceOfHook _hook) external;
 

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.15;
 import {IBalanceOfHook} from "./IBalanceOfHook.sol";
 import {IOwnerOfHook} from "./IOwnerOfHook.sol";
 import {ISafeTransferFromHook} from "./ISafeTransferFromHook.sol";
+import {ITransferFromHook} from "./ITransferFromHook.sol";
+import {IApproveHook} from "./IApproveHook.sol";
 
 interface IERC721ACH {
     /// @notice error onlyOwner
@@ -32,6 +34,11 @@ interface IERC721ACH {
     /// @param hook The new hook
     event UpdatedHookTransferFrom(address indexed caller, address indexed hook);
 
+    /// @notice Emitted when approve hook is set
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHookApprove(address indexed caller, address indexed hook);
+
     /// TODO
     function setBalanceOfHook(IBalanceOfHook _hook) external;
 
@@ -40,4 +47,10 @@ interface IERC721ACH {
 
     /// TODO
     function setSafeTransferFromHook(ISafeTransferFromHook _hook) external;
+
+    /// TODO
+    function setTransferFromHook(ITransferFromHook _hook) external;
+
+    /// TODO
+    function setApproveHook(IApproveHook _hook) external;
 }

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -27,9 +27,12 @@ interface IERC721ACH {
         address indexed hook
     );
 
+    /// TODO
     function setBalanceOfHook(IBalanceOfHook _hook) external;
 
+    /// TODO
     function setOwnerOfHook(IOwnerOfHook _hook) external;
 
+    /// TODO
     function setSafeTransferFromHook(ISafeTransferFromHook _hook) external;
 }

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -6,6 +6,7 @@ import {IOwnerOfHook} from "./IOwnerOfHook.sol";
 import {ISafeTransferFromHook} from "./ISafeTransferFromHook.sol";
 import {ITransferFromHook} from "./ITransferFromHook.sol";
 import {IApproveHook} from "./IApproveHook.sol";
+import {ISetApprovalForAllHook} from "./ISetApprovalForAllHook.sol";
 
 interface IERC721ACH {
     /// @notice error onlyOwner
@@ -39,6 +40,14 @@ interface IERC721ACH {
     /// @param hook The new hook
     event UpdatedHookApprove(address indexed caller, address indexed hook);
 
+    /// @notice Emitted when setApprovalForAll hook is set
+    /// @param caller The caller
+    /// @param hook The new hook
+    event UpdatedHookSetApprovalForAll(
+        address indexed caller,
+        address indexed hook
+    );
+
     /// TODO
     function setBalanceOfHook(IBalanceOfHook _hook) external;
 
@@ -53,4 +62,7 @@ interface IERC721ACH {
 
     /// TODO
     function setApproveHook(IApproveHook _hook) external;
+
+    /// TODO
+    function setSetApprovalForAllHook(ISetApprovalForAllHook _hook) external;
 }

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+import {IBalanceOfHook} from "./IBalanceOfHook.sol";
+import {IOwnerOfHook} from "./IOwnerOfHook.sol";
+import {ISafeTransferFromHook} from "./ISafeTransferFromHook.sol";
+
 interface IERC721ACH {
     /// @notice error onlyOwner
     error Access_OnlyOwner();
@@ -8,18 +12,24 @@ interface IERC721ACH {
     /// @notice Emitted when balanceOf hook is used
     /// @param caller The caller
     /// @param hook The new hook
-    event UpdatedHook_BalanceOf(address indexed caller, address indexed hook);
+    event UpdatedHookBalanceOf(address indexed caller, address indexed hook);
 
     /// @notice Emitted when ownerOf hook is set
     /// @param caller The caller
     /// @param hook The new hook
-    event UpdatedHook_OwnerOf(address indexed caller, address indexed hook);
+    event UpdatedHookOwnerOf(address indexed caller, address indexed hook);
 
     /// @notice Emitted when safeTransferFrom hook is set
     /// @param caller The caller
     /// @param hook The new hook
-    event UpdatedHook_SafeTransferFrom(
+    event UpdatedHookSafeTransferFrom(
         address indexed caller,
         address indexed hook
     );
+
+    function setBalanceOfHook(IBalanceOfHook _hook) external;
+
+    function setOwnerOfHook(IOwnerOfHook _hook) external;
+
+    function setSafeTransferFromHook(ISafeTransferFromHook _hook) external;
 }

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -7,6 +7,8 @@ import {ISafeTransferFromHook} from "./ISafeTransferFromHook.sol";
 import {ITransferFromHook} from "./ITransferFromHook.sol";
 import {IApproveHook} from "./IApproveHook.sol";
 import {ISetApprovalForAllHook} from "./ISetApprovalForAllHook.sol";
+import {IGetApprovedHook} from "./IGetApprovedHook.sol";
+import {IIsApprovedForAllHook} from "./IIsApprovedForAllHook.sol";
 
 interface IERC721ACH {
     /// @notice error onlyOwner
@@ -78,4 +80,10 @@ interface IERC721ACH {
 
     /// TODO
     function setSetApprovalForAllHook(ISetApprovalForAllHook _hook) external;
+
+    /// TODO
+    function setGetApprovedHook(IGetApprovedHook _hook) external;
+
+    /// TODO
+    function setIsApprovedForAllHook(IIsApprovedForAllHook _hook) external;
 }

--- a/src/interfaces/IGetApprovedHook.sol
+++ b/src/interfaces/IGetApprovedHook.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface IGetApprovedHook {
+    /// @notice Check if the getApproved function should use hook.
+    /// @param tokenId The token ID to query the approval of
+    /// @dev Returns whether or not to use the hook for getApproved function
+    function useGetApprovedHook(uint256 tokenId) external view returns (bool);
+
+    /// @notice getApproved Hook for custom implementation.
+    /// @param tokenId The token ID to query the approval of
+    /// @dev Returns the approved address for a token ID, or zero if no address set
+    function getApprovedOverrideHook(
+        uint256 tokenId
+    ) external view returns (address);
+}

--- a/src/interfaces/IIsApprovedForAllHook.sol
+++ b/src/interfaces/IIsApprovedForAllHook.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface IIsApprovedForAllHook {
+    /// @notice Check if the isApprovedForAll function should use hook.
+    /// @param owner The address that owns the NFTs
+    /// @param operator The address that acts on behalf of the owner
+    /// @dev Returns whether or not to use the hook for isApprovedForAll function
+    function useIsApprovedForAllHook(
+        address owner,
+        address operator
+    ) external view returns (bool);
+
+    /// @notice isApprovedForAll Hook for custom implementation.
+    /// @param owner The address that owns the NFTs
+    /// @param operator The address that acts on behalf of the owner
+    /// @dev Returns whether an operator is approved by a given owner
+    function isApprovedForAllOverrideHook(
+        address owner,
+        address operator
+    ) external view returns (bool);
+}

--- a/src/interfaces/IOwnerOfHook.sol
+++ b/src/interfaces/IOwnerOfHook.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface IOwnerOfHook {
+    /// @notice ownerOf Hook for custom implementation.
+    /// @param tokenId The token ID to query the owner of
+    /// @dev Returns the owner of the specified token ID
+    function ownerOfOverrideHook(
+        uint256 tokenId
+    ) external view returns (address);
+
+    /// @notice Check if the ownerOf function should use hook.
+    /// @param tokenId The token ID to query the owner of
+    /// @dev Returns whether or not to use the hook for ownerOf function
+    function useOwnerOfHook(uint256 tokenId) external view returns (bool);
+}

--- a/src/interfaces/ISafeTransferFromHook.sol
+++ b/src/interfaces/ISafeTransferFromHook.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface ISafeTransferFromHook {
+    /// @notice Emitted when safeTransferFrom hook is used
+    /// @param sender The sender of the token
+    /// @param from The current owner of the token
+    /// @param to The receiver of the token
+    /// @param tokenId The ID of the token
+    /// @param data Additional data
+    event SafeTransferFromHookUsed(
+        address indexed sender,
+        address indexed from,
+        address indexed to,
+        uint256 tokenId,
+        bytes data
+    );
+
+    /// @notice safeTransferFrom Hook for custom implementation.
+    /// @param sender The address which calls `safeTransferFrom`
+    /// @param from The current owner of the NFT
+    /// @param to The new owner
+    /// @param tokenId The NFT to transfer
+    /// @param data Additional data with no specified format, sent in call to `to`
+    function safeTransferFromOverrideHook(
+        address sender,
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) external;
+
+    /// @notice Check if the safeTransferFrom function should use hook.
+    /// @param sender The address which calls `safeTransferFrom`
+    /// @param from The current owner of the NFT
+    /// @param to The new owner
+    /// @param tokenId The NFT to transfer
+    /// @param data Additional data with no specified format, sent in call to `to`
+    /// @dev Returns whether or not to use the hook for safeTransferFrom function
+    function useSafeTransferFromHook(
+        address sender,
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) external view returns (bool);
+}

--- a/src/interfaces/ISetApprovalForAllHook.sol
+++ b/src/interfaces/ISetApprovalForAllHook.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface ISetApprovalForAllHook {
+    /// @notice Emitted when setApprovalForAll hook is used
+    /// @param owner The owner of the tokens
+    /// @param operator The operator that got (dis)approved
+    /// @param approved The approval status
+    event SetApprovalForAllHookUsed(
+        address indexed owner,
+        address indexed operator,
+        bool approved
+    );
+
+    /// @notice Check if the setApprovalForAll function should use hook.
+    /// @param owner The address to extend operators for
+    /// @param operator The address to add to the set of authorized operators
+    /// @param approved True if the operator is approved, false to revoke approval
+    /// @dev Returns whether or not to use the hook for setApprovalForAll function
+    function useSetApprovalForAllHook(
+        address owner,
+        address operator,
+        bool approved
+    ) external view returns (bool);
+
+    /// @notice setApprovalForAll Hook for custom implementation.
+    /// @param owner The address to extend operators for
+    /// @param operator The address to add to the set of authorized operators
+    /// @param approved True if the operator is approved, false to revoke approval
+    function setApprovalForAllOverrideHook(
+        address owner,
+        address operator,
+        bool approved
+    ) external;
+}

--- a/src/interfaces/ITransferFromHook.sol
+++ b/src/interfaces/ITransferFromHook.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface ITransferFromHook {
+    /// @notice Emitted when transferFrom hook is used
+    /// @param from The current owner of the token
+    /// @param to The receiver of the token
+    /// @param tokenId The ID of the token
+    event TransferFromHookUsed(
+        address indexed from,
+        address indexed to,
+        uint256 tokenId
+    );
+
+    /// @notice transferFrom Hook for custom implementation.
+    /// @param from The current owner of the NFT
+    /// @param to The new owner
+    /// @param tokenId The NFT to transfer
+    function transferFromOverrideHook(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
+
+    /// @notice Check if the transferFrom function should use hook.
+    /// @param from The current owner of the NFT
+    /// @param to The new owner
+    /// @param tokenId The NFT to transfer
+    /// @dev Returns whether or not to use the hook for transferFrom function
+    function useTransferFromHook(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external view returns (bool);
+}

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -85,34 +85,6 @@ contract ERC721ACHTest is DSTest {
         );
     }
 
-    function test_approve(
-        uint256 _mintQuantity,
-        uint256 _tokenToApprove
-    ) public {
-        vm.assume(_mintQuantity > 0);
-        vm.assume(_tokenToApprove > 0);
-        vm.assume(_mintQuantity < 10_000);
-        vm.assume(_tokenToApprove <= _mintQuantity);
-
-        // Mint some tokens first
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
-
-        // Verify normal functionality
-        assertEq(address(0), erc721Mock.getApproved(_tokenToApprove));
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
-        assertEq(
-            DEFAULT_OWNER_ADDRESS,
-            erc721Mock.getApproved(_tokenToApprove)
-        );
-
-        // Verify hook override
-        erc721Mock.setHooksEnabled(true);
-        vm.expectRevert(ERC721ACHMock.ApproveHook_Executed.selector);
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
-    }
-
     function test_setApprovalForAll(uint256 _mintQuantity) public {
         vm.assume(_mintQuantity > 0);
         vm.assume(_mintQuantity < 10_000);

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -181,34 +181,4 @@ contract ERC721ACHTest is DSTest {
             )
         );
     }
-
-    function test_transferFrom(uint256 _mintQuantity, uint256 _tokenId) public {
-        vm.assume(_tokenId > 0);
-        vm.assume(_mintQuantity > 0);
-        vm.assume(_mintQuantity < 10_000);
-        vm.assume(_mintQuantity >= _tokenId);
-
-        // Mint some tokens first
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
-
-        // Verify normal functionality
-        assertEq(DEFAULT_BUYER_ADDRESS, erc721Mock.ownerOf(_tokenId));
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.transferFrom(
-            DEFAULT_BUYER_ADDRESS,
-            DEFAULT_OWNER_ADDRESS,
-            _tokenId
-        );
-        assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.ownerOf(_tokenId));
-
-        // Verify hook override
-        erc721Mock.setHooksEnabled(true);
-        vm.expectRevert(ERC721ACHMock.TransferFromHook_Executed.selector);
-        vm.prank(DEFAULT_OWNER_ADDRESS);
-        erc721Mock.transferFrom(
-            DEFAULT_OWNER_ADDRESS,
-            DEFAULT_BUYER_ADDRESS,
-            _tokenId
-        );
-    }
 }

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -11,6 +11,7 @@ import {IOwnerOfHook} from "../src/interfaces/IOwnerOfHook.sol";
 import {ISafeTransferFromHook} from "../src/interfaces/ISafeTransferFromHook.sol";
 import {ITransferFromHook} from "../src/interfaces/ITransferFromHook.sol";
 import {IApproveHook} from "../src/interfaces/IApproveHook.sol";
+import {ISetApprovalForAllHook} from "../src/interfaces/ISetApprovalForAllHook.sol";
 import {IERC721ACH} from "../src/interfaces/IERC721ACH.sol";
 
 contract ERC721ACHTest is DSTest {
@@ -97,6 +98,20 @@ contract ERC721ACHTest is DSTest {
         assertEq(
             isOwner ? hook : address(0),
             address(erc721Mock.approveHook())
+        );
+    }
+
+    function test_setApprovalForAllHook(address hook, address caller) public {
+        assertEq(address(0), address(erc721Mock.setApprovalForAllHook()));
+        bool isOwner = caller == DEFAULT_OWNER_ADDRESS;
+        vm.prank(caller);
+        if (!isOwner) {
+            vm.expectRevert(IERC721ACH.Access_OnlyOwner.selector);
+        }
+        erc721Mock.setSetApprovalForAllHook(ISetApprovalForAllHook(hook));
+        assertEq(
+            isOwner ? hook : address(0),
+            address(erc721Mock.setApprovalForAllHook())
         );
     }
 

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -30,6 +30,7 @@ contract ERC721ACHTest is DSTest {
     function test_balanceOfHook(address hook, address caller) public {
         assertEq(address(0), address(erc721Mock.balanceOfHook()));
         bool isOwner = caller == DEFAULT_OWNER_ADDRESS;
+        vm.prank(caller);
         if (!isOwner) {
             vm.expectRevert(IERC721ACH.Access_OnlyOwner.selector);
         }
@@ -43,6 +44,7 @@ contract ERC721ACHTest is DSTest {
     function test_ownerOfHook(address hook, address caller) public {
         assertEq(address(0), address(erc721Mock.ownerOfHook()));
         bool isOwner = caller == DEFAULT_OWNER_ADDRESS;
+        vm.prank(caller);
         if (!isOwner) {
             vm.expectRevert(IERC721ACH.Access_OnlyOwner.selector);
         }

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -12,6 +12,7 @@ import {ISafeTransferFromHook} from "../src/interfaces/ISafeTransferFromHook.sol
 import {ITransferFromHook} from "../src/interfaces/ITransferFromHook.sol";
 import {IApproveHook} from "../src/interfaces/IApproveHook.sol";
 import {ISetApprovalForAllHook} from "../src/interfaces/ISetApprovalForAllHook.sol";
+import {IGetApprovedHook} from "../src/interfaces/IGetApprovedHook.sol";
 import {IERC721ACH} from "../src/interfaces/IERC721ACH.sol";
 
 contract ERC721ACHTest is DSTest {
@@ -112,6 +113,20 @@ contract ERC721ACHTest is DSTest {
         assertEq(
             isOwner ? hook : address(0),
             address(erc721Mock.setApprovalForAllHook())
+        );
+    }
+
+    function test_getApprovedHook(address hook, address caller) public {
+        assertEq(address(0), address(erc721Mock.getApprovedHook()));
+        bool isOwner = caller == DEFAULT_OWNER_ADDRESS;
+        vm.prank(caller);
+        if (!isOwner) {
+            vm.expectRevert(IERC721ACH.Access_OnlyOwner.selector);
+        }
+        erc721Mock.setGetApprovedHook(IGetApprovedHook(hook));
+        assertEq(
+            isOwner ? hook : address(0),
+            address(erc721Mock.getApprovedHook())
         );
     }
 

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -129,37 +129,4 @@ contract ERC721ACHTest is DSTest {
             address(erc721Mock.getApprovedHook())
         );
     }
-
-    function test_isApprovedForAll(uint256 _mintQuantity) public {
-        vm.assume(_mintQuantity > 0);
-        vm.assume(_mintQuantity < 10_000);
-
-        // Mint some tokens first
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
-
-        // Verify normal functionality
-        assertTrue(
-            !erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.setApprovalForAll(DEFAULT_OWNER_ADDRESS, true);
-        assertTrue(
-            erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
-
-        // Verify hook override
-        erc721Mock.setHooksEnabled(true);
-        assertTrue(
-            !erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
-    }
 }

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -5,6 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "./utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {BalanceOfHookTest} from "./hooks/BalanceOfHook.t.sol";
 
 contract ERC721ACHTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);
@@ -21,20 +22,6 @@ contract ERC721ACHTest is DSTest {
     function test_Erc721() public {
         assertEq("ERC-721ACH Mock", erc721Mock.name());
         assertEq("MOCK", erc721Mock.symbol());
-    }
-
-    function test_balanceOf(uint256 _mintQuantity) public {
-        vm.assume(_mintQuantity > 0);
-        vm.assume(_mintQuantity < 10_000);
-
-        // Verify normal functionality
-        assertEq(0, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
-        assertEq(_mintQuantity, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
-
-        // Verify hook override
-        erc721Mock.setHooksEnabled(true);
-        assertEq(0, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
     }
 
     function test_ownerOf(uint256 _mintQuantity) public {

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -6,6 +6,7 @@ import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "./utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
 import {BalanceOfHookTest} from "./hooks/BalanceOfHook.t.sol";
+import {IBalanceOfHook} from "../src/interfaces/IBalanceOfHook.sol";
 
 contract ERC721ACHTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);
@@ -22,6 +23,12 @@ contract ERC721ACHTest is DSTest {
     function test_Erc721() public {
         assertEq("ERC-721ACH Mock", erc721Mock.name());
         assertEq("MOCK", erc721Mock.symbol());
+    }
+
+    function test_balanceOfHook(address balanceOfHook) public {
+        assertEq(address(0), address(erc721Mock.balanceOfHook()));
+        erc721Mock.setBalanceOfHook(IBalanceOfHook(balanceOfHook));
+        assertEq(balanceOfHook, address(erc721Mock.balanceOfHook()));
     }
 
     function test_ownerOf(uint256 _mintQuantity) public {

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -100,36 +100,6 @@ contract ERC721ACHTest is DSTest {
         );
     }
 
-    function test_setApprovalForAll(uint256 _mintQuantity) public {
-        vm.assume(_mintQuantity > 0);
-        vm.assume(_mintQuantity < 10_000);
-
-        // Mint some tokens first
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
-
-        // Verify normal functionality
-        assertTrue(
-            !erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.setApprovalForAll(DEFAULT_OWNER_ADDRESS, true);
-        assertTrue(
-            erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
-
-        // Verify hook override
-        erc721Mock.setHooksEnabled(true);
-        vm.expectRevert(ERC721ACHMock.SetApprovalForAllHook_Executed.selector);
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.setApprovalForAll(DEFAULT_OWNER_ADDRESS, true);
-    }
-
     function test_getApproved(uint256 _mintQuantity, uint256 _tokenId) public {
         vm.assume(_tokenId > 0);
         vm.assume(_mintQuantity > 0);

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -10,6 +10,7 @@ import {IBalanceOfHook} from "../src/interfaces/IBalanceOfHook.sol";
 import {IOwnerOfHook} from "../src/interfaces/IOwnerOfHook.sol";
 import {ISafeTransferFromHook} from "../src/interfaces/ISafeTransferFromHook.sol";
 import {ITransferFromHook} from "../src/interfaces/ITransferFromHook.sol";
+import {IApproveHook} from "../src/interfaces/IApproveHook.sol";
 import {IERC721ACH} from "../src/interfaces/IERC721ACH.sol";
 
 contract ERC721ACHTest is DSTest {
@@ -82,6 +83,20 @@ contract ERC721ACHTest is DSTest {
         assertEq(
             isOwner ? hook : address(0),
             address(erc721Mock.transferFromHook())
+        );
+    }
+
+    function test_approveHook(address hook, address caller) public {
+        assertEq(address(0), address(erc721Mock.approveHook()));
+        bool isOwner = caller == DEFAULT_OWNER_ADDRESS;
+        vm.prank(caller);
+        if (!isOwner) {
+            vm.expectRevert(IERC721ACH.Access_OnlyOwner.selector);
+        }
+        erc721Mock.setApproveHook(IApproveHook(hook));
+        assertEq(
+            isOwner ? hook : address(0),
+            address(erc721Mock.approveHook())
         );
     }
 

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -13,6 +13,7 @@ import {ITransferFromHook} from "../src/interfaces/ITransferFromHook.sol";
 import {IApproveHook} from "../src/interfaces/IApproveHook.sol";
 import {ISetApprovalForAllHook} from "../src/interfaces/ISetApprovalForAllHook.sol";
 import {IGetApprovedHook} from "../src/interfaces/IGetApprovedHook.sol";
+import {IIsApprovedForAllHook} from "../src/interfaces/IIsApprovedForAllHook.sol";
 import {IERC721ACH} from "../src/interfaces/IERC721ACH.sol";
 
 contract ERC721ACHTest is DSTest {
@@ -127,6 +128,20 @@ contract ERC721ACHTest is DSTest {
         assertEq(
             isOwner ? hook : address(0),
             address(erc721Mock.getApprovedHook())
+        );
+    }
+
+    function test_isApprovedForAllHook(address hook, address caller) public {
+        assertEq(address(0), address(erc721Mock.isApprovedForAllHook()));
+        bool isOwner = caller == DEFAULT_OWNER_ADDRESS;
+        vm.prank(caller);
+        if (!isOwner) {
+            vm.expectRevert(IERC721ACH.Access_OnlyOwner.selector);
+        }
+        erc721Mock.setIsApprovedForAllHook(IIsApprovedForAllHook(hook));
+        assertEq(
+            isOwner ? hook : address(0),
+            address(erc721Mock.isApprovedForAllHook())
         );
     }
 }

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -9,6 +9,7 @@ import {BalanceOfHookTest} from "./hooks/BalanceOfHook.t.sol";
 import {IBalanceOfHook} from "../src/interfaces/IBalanceOfHook.sol";
 import {IOwnerOfHook} from "../src/interfaces/IOwnerOfHook.sol";
 import {ISafeTransferFromHook} from "../src/interfaces/ISafeTransferFromHook.sol";
+import {ITransferFromHook} from "../src/interfaces/ITransferFromHook.sol";
 import {IERC721ACH} from "../src/interfaces/IERC721ACH.sol";
 
 contract ERC721ACHTest is DSTest {
@@ -67,6 +68,20 @@ contract ERC721ACHTest is DSTest {
         assertEq(
             isOwner ? hook : address(0),
             address(erc721Mock.safeTransferFromHook())
+        );
+    }
+
+    function test_transferFromHook(address hook, address caller) public {
+        assertEq(address(0), address(erc721Mock.transferFromHook()));
+        bool isOwner = caller == DEFAULT_OWNER_ADDRESS;
+        vm.prank(caller);
+        if (!isOwner) {
+            vm.expectRevert(IERC721ACH.Access_OnlyOwner.selector);
+        }
+        erc721Mock.setTransferFromHook(ITransferFromHook(hook));
+        assertEq(
+            isOwner ? hook : address(0),
+            address(erc721Mock.transferFromHook())
         );
     }
 

--- a/test/ERC721ACH.t.sol
+++ b/test/ERC721ACH.t.sol
@@ -115,27 +115,6 @@ contract ERC721ACHTest is DSTest {
         );
     }
 
-    function test_getApproved(uint256 _mintQuantity, uint256 _tokenId) public {
-        vm.assume(_tokenId > 0);
-        vm.assume(_mintQuantity > 0);
-        vm.assume(_mintQuantity < 10_000);
-        vm.assume(_mintQuantity >= _tokenId);
-
-        // Mint some tokens first
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
-
-        // Verify normal functionality
-        assertEq(address(0), erc721Mock.getApproved(_tokenId));
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenId);
-        assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.getApproved(_tokenId));
-
-        // Verify hook override
-        erc721Mock.setHooksEnabled(true);
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        assertEq(address(0), erc721Mock.getApproved(_tokenId));
-    }
-
     function test_isApprovedForAll(uint256 _mintQuantity) public {
         vm.assume(_mintQuantity > 0);
         vm.assume(_mintQuantity < 10_000);

--- a/test/HookManagers/BalanceOfHook.t.sol
+++ b/test/HookManagers/BalanceOfHook.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+
+contract BalanceOfHookTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+
+    function setUp() public {
+        vm.startPrank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock = new ERC721ACHMock();
+        vm.stopPrank();
+    }
+
+    function test_balanceOfHookManager() public {
+        assertEq(address(0), address(erc721Mock.balanceOfHook()));
+    }
+
+    function test_balanceOf(uint256 _mintQuantity) public {
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_mintQuantity < 10_000);
+
+        // Verify normal functionality
+        assertEq(0, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
+        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+        assertEq(_mintQuantity, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
+
+        // Verify hook override
+        erc721Mock.setHooksEnabled(true);
+        assertEq(0, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
+    }
+}

--- a/test/hooks/ApproveHook.t.sol
+++ b/test/hooks/ApproveHook.t.sol
@@ -52,9 +52,10 @@ contract ApproveHookTest is DSTest {
         );
 
         // Verify hook override
-        // hookMock.setHooksEnabled(true);
-        // vm.expectRevert(ERC721ACHMock.ApproveHook_Executed.selector);
-        // vm.prank(DEFAULT_BUYER_ADDRESS);
-        // erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
+        test_setApproveHook();
+        hookMock.setHooksEnabled(true);
+        vm.expectRevert(ApproveHookMock.ApproveHook_Executed.selector);
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
     }
 }

--- a/test/hooks/ApproveHook.t.sol
+++ b/test/hooks/ApproveHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {ApproveHookMock} from "../utils/Hooks/ApproveHookMock.sol";
+import {ApproveHookMock} from "../utils/hooks/ApproveHookMock.sol";
 
 contract ApproveHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/ApproveHook.t.sol
+++ b/test/hooks/ApproveHook.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {ApproveHookMock} from "../utils/Hooks/ApproveHookMock.sol";
+
+contract ApproveHookTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+    ApproveHookMock hookMock;
+
+    function setUp() public {
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
+        hookMock = new ApproveHookMock();
+    }
+
+    function test_approveHook() public {
+        assertEq(address(0), address(erc721Mock.approveHook()));
+    }
+
+    function test_setApproveHook() public {
+        assertEq(address(0), address(erc721Mock.approveHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock.setApproveHook(hookMock);
+        assertEq(address(hookMock), address(erc721Mock.approveHook()));
+    }
+
+    function test_approve(
+        uint256 _mintQuantity,
+        uint256 _tokenToApprove
+    ) public {
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_tokenToApprove > 0);
+        vm.assume(_mintQuantity < 10_000);
+        vm.assume(_tokenToApprove <= _mintQuantity);
+
+        // Mint some tokens first
+        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+
+        // Verify normal functionality
+        assertEq(address(0), erc721Mock.getApproved(_tokenToApprove));
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
+        assertEq(
+            DEFAULT_OWNER_ADDRESS,
+            erc721Mock.getApproved(_tokenToApprove)
+        );
+
+        // Verify hook override
+        // hookMock.setHooksEnabled(true);
+        // vm.expectRevert(ERC721ACHMock.ApproveHook_Executed.selector);
+        // vm.prank(DEFAULT_BUYER_ADDRESS);
+        // erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
+    }
+}

--- a/test/hooks/BalanceOfHook.t.sol
+++ b/test/hooks/BalanceOfHook.t.sol
@@ -5,21 +5,30 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {BalanceOfHookMock} from "../utils/Hooks/BalanceOfHookMock.sol";
 
 contract BalanceOfHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);
     address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
     address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
     ERC721ACHMock erc721Mock;
+    BalanceOfHookMock hookMock;
 
     function setUp() public {
         vm.startPrank(DEFAULT_OWNER_ADDRESS);
         erc721Mock = new ERC721ACHMock();
+        hookMock = new BalanceOfHookMock();
         vm.stopPrank();
     }
 
-    function test_balanceOfHookManager() public {
+    function test_balanceOfHook() public {
         assertEq(address(0), address(erc721Mock.balanceOfHook()));
+    }
+
+    function test_setBalanceOfHook() public {
+        assertEq(address(0), address(erc721Mock.balanceOfHook()));
+        erc721Mock.setBalanceOfHook(hookMock);
+        assertEq(address(hookMock), address(erc721Mock.balanceOfHook()));
     }
 
     function test_balanceOf(uint256 _mintQuantity) public {
@@ -32,7 +41,8 @@ contract BalanceOfHookTest is DSTest {
         assertEq(_mintQuantity, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
 
         // Verify hook override
-        erc721Mock.setHooksEnabled(true);
+        test_setBalanceOfHook();
+        hookMock.setHooksEnabled(true);
         assertEq(0, erc721Mock.balanceOf(DEFAULT_BUYER_ADDRESS));
     }
 }

--- a/test/hooks/BalanceOfHook.t.sol
+++ b/test/hooks/BalanceOfHook.t.sol
@@ -25,6 +25,7 @@ contract BalanceOfHookTest is DSTest {
 
     function test_setBalanceOfHook() public {
         assertEq(address(0), address(erc721Mock.balanceOfHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
         erc721Mock.setBalanceOfHook(hookMock);
         assertEq(address(hookMock), address(erc721Mock.balanceOfHook()));
     }

--- a/test/hooks/BalanceOfHook.t.sol
+++ b/test/hooks/BalanceOfHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {BalanceOfHookMock} from "../utils/Hooks/BalanceOfHookMock.sol";
+import {BalanceOfHookMock} from "../utils/hooks/BalanceOfHookMock.sol";
 
 contract BalanceOfHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/BalanceOfHook.t.sol
+++ b/test/hooks/BalanceOfHook.t.sol
@@ -15,10 +15,8 @@ contract BalanceOfHookTest is DSTest {
     BalanceOfHookMock hookMock;
 
     function setUp() public {
-        vm.startPrank(DEFAULT_OWNER_ADDRESS);
-        erc721Mock = new ERC721ACHMock();
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
         hookMock = new BalanceOfHookMock();
-        vm.stopPrank();
     }
 
     function test_balanceOfHook() public {

--- a/test/hooks/GetApprovedHook.t.sol
+++ b/test/hooks/GetApprovedHook.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {GetApprovedHookMock} from "../utils/Hooks/GetApprovedHookMock.sol";
+
+contract GetApprovedHookTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+    GetApprovedHookMock hookMock;
+
+    function setUp() public {
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
+        hookMock = new GetApprovedHookMock();
+    }
+
+    function test_getApprovedHook() public {
+        assertEq(address(0), address(erc721Mock.getApprovedHook()));
+    }
+
+    function test_setGetApprovedHook() public {
+        assertEq(address(0), address(erc721Mock.getApprovedHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock.setGetApprovedHook(hookMock);
+        assertEq(address(hookMock), address(erc721Mock.getApprovedHook()));
+    }
+
+    function test_getApproved(uint256 _mintQuantity, uint256 _tokenId) public {
+        vm.assume(_tokenId > 0);
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_mintQuantity < 10_000);
+        vm.assume(_mintQuantity >= _tokenId);
+
+        // Mint some tokens first
+        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+
+        // Verify normal functionality
+        assertEq(address(0), erc721Mock.getApproved(_tokenId));
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenId);
+        assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.getApproved(_tokenId));
+
+        // Verify hook override
+        test_setGetApprovedHook();
+        hookMock.setHooksEnabled(true);
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        assertEq(address(0), erc721Mock.getApproved(_tokenId));
+    }
+}

--- a/test/hooks/GetApprovedHook.t.sol
+++ b/test/hooks/GetApprovedHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {GetApprovedHookMock} from "../utils/Hooks/GetApprovedHookMock.sol";
+import {GetApprovedHookMock} from "../utils/hooks/GetApprovedHookMock.sol";
 
 contract GetApprovedHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/IsApprovedForAllHook.t.sol
+++ b/test/hooks/IsApprovedForAllHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {IsApprovedForAllHookMock} from "../utils/Hooks/IsApprovedForAllHookMock.sol";
+import {IsApprovedForAllHookMock} from "../utils/hooks/IsApprovedForAllHookMock.sol";
 
 contract IsApprovedForAllHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/IsApprovedForAllHook.t.sol
+++ b/test/hooks/IsApprovedForAllHook.t.sol
@@ -30,37 +30,27 @@ contract IsApprovedForAllHookTest is DSTest {
         assertEq(address(hookMock), address(erc721Mock.isApprovedForAllHook()));
     }
 
-    function test_isApprovedForAll(uint256 _mintQuantity) public {
+    function test_isApprovedForAll(
+        uint256 _mintQuantity,
+        address buyer
+    ) public {
         vm.assume(_mintQuantity > 0);
         vm.assume(_mintQuantity < 10_000);
+        vm.assume(buyer != address(0));
+        vm.assume(buyer != DEFAULT_OWNER_ADDRESS);
 
         // Mint some tokens first
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+        erc721Mock.mint(buyer, _mintQuantity);
 
         // Verify normal functionality
-        assertTrue(
-            !erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
-        vm.prank(DEFAULT_BUYER_ADDRESS);
+        assertTrue(!erc721Mock.isApprovedForAll(buyer, DEFAULT_OWNER_ADDRESS));
+        vm.prank(buyer);
         erc721Mock.setApprovalForAll(DEFAULT_OWNER_ADDRESS, true);
-        assertTrue(
-            erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
+        assertTrue(erc721Mock.isApprovedForAll(buyer, DEFAULT_OWNER_ADDRESS));
 
         // Verify hook override
         test_setIsApprovedForAllHook();
         hookMock.setHooksEnabled(true);
-        assertTrue(
-            !erc721Mock.isApprovedForAll(
-                DEFAULT_BUYER_ADDRESS,
-                DEFAULT_OWNER_ADDRESS
-            )
-        );
+        assertTrue(!erc721Mock.isApprovedForAll(buyer, DEFAULT_OWNER_ADDRESS));
     }
 }

--- a/test/hooks/IsApprovedForAllHook.t.sol
+++ b/test/hooks/IsApprovedForAllHook.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {IsApprovedForAllHookMock} from "../utils/Hooks/IsApprovedForAllHookMock.sol";
+
+contract IsApprovedForAllHookTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+    IsApprovedForAllHookMock hookMock;
+
+    function setUp() public {
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
+        hookMock = new IsApprovedForAllHookMock();
+    }
+
+    function test_isApprovedForAllHook() public {
+        assertEq(address(0), address(erc721Mock.isApprovedForAllHook()));
+    }
+
+    function test_setIsApprovedForAllHook() public {
+        assertEq(address(0), address(erc721Mock.isApprovedForAllHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock.setIsApprovedForAllHook(hookMock);
+        assertEq(address(hookMock), address(erc721Mock.isApprovedForAllHook()));
+    }
+
+    function test_isApprovedForAll(uint256 _mintQuantity) public {
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_mintQuantity < 10_000);
+
+        // Mint some tokens first
+        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+
+        // Verify normal functionality
+        assertTrue(
+            !erc721Mock.isApprovedForAll(
+                DEFAULT_BUYER_ADDRESS,
+                DEFAULT_OWNER_ADDRESS
+            )
+        );
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.setApprovalForAll(DEFAULT_OWNER_ADDRESS, true);
+        assertTrue(
+            erc721Mock.isApprovedForAll(
+                DEFAULT_BUYER_ADDRESS,
+                DEFAULT_OWNER_ADDRESS
+            )
+        );
+
+        // Verify hook override
+        test_setIsApprovedForAllHook();
+        hookMock.setHooksEnabled(true);
+        assertTrue(
+            !erc721Mock.isApprovedForAll(
+                DEFAULT_BUYER_ADDRESS,
+                DEFAULT_OWNER_ADDRESS
+            )
+        );
+    }
+}

--- a/test/hooks/OwnerOfHook.t.sol
+++ b/test/hooks/OwnerOfHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {OwnerOfHookMock} from "../utils/Hooks/OwnerOfHookMock.sol";
+import {OwnerOfHookMock} from "../utils/hooks/OwnerOfHookMock.sol";
 
 contract OwnerOfHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/OwnerOfHook.t.sol
+++ b/test/hooks/OwnerOfHook.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {OwnerOfHookMock} from "../utils/Hooks/OwnerOfHookMock.sol";
+
+contract OwnerOfHookTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+    OwnerOfHookMock hookMock;
+
+    function setUp() public {
+        vm.startPrank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock = new ERC721ACHMock();
+        hookMock = new OwnerOfHookMock();
+        vm.stopPrank();
+    }
+
+    function test_ownerOfHook() public {
+        assertEq(address(0), address(erc721Mock.ownerOfHook()));
+    }
+
+    function test_setOwnerOfHook() public {
+        assertEq(address(0), address(erc721Mock.ownerOfHook()));
+        erc721Mock.setOwnerOfHook(hookMock);
+        assertEq(address(hookMock), address(erc721Mock.ownerOfHook()));
+    }
+
+    function test_ownerOf(uint256 _mintQuantity, address buyer) public {
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_mintQuantity < 10_000);
+        vm.assume(buyer != address(0));
+
+        // Verify normal functionality
+        vm.expectRevert();
+        assertEq(address(0), erc721Mock.ownerOf(_mintQuantity));
+        erc721Mock.mint(buyer, _mintQuantity);
+        assertEq(address(buyer), erc721Mock.ownerOf(_mintQuantity));
+
+        // Verify hook override
+        test_setOwnerOfHook();
+        hookMock.setHooksEnabled(true);
+        assertEq(address(0), erc721Mock.ownerOf(_mintQuantity));
+    }
+}

--- a/test/hooks/OwnerOfHook.t.sol
+++ b/test/hooks/OwnerOfHook.t.sol
@@ -15,10 +15,8 @@ contract OwnerOfHookTest is DSTest {
     OwnerOfHookMock hookMock;
 
     function setUp() public {
-        vm.startPrank(DEFAULT_OWNER_ADDRESS);
-        erc721Mock = new ERC721ACHMock();
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
         hookMock = new OwnerOfHookMock();
-        vm.stopPrank();
     }
 
     function test_ownerOfHook() public {

--- a/test/hooks/OwnerOfHook.t.sol
+++ b/test/hooks/OwnerOfHook.t.sol
@@ -25,6 +25,7 @@ contract OwnerOfHookTest is DSTest {
 
     function test_setOwnerOfHook() public {
         assertEq(address(0), address(erc721Mock.ownerOfHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
         erc721Mock.setOwnerOfHook(hookMock);
         assertEq(address(hookMock), address(erc721Mock.ownerOfHook()));
     }

--- a/test/hooks/SafeTransferFromHook.t.sol
+++ b/test/hooks/SafeTransferFromHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {SafeTransferFromHookMock} from "../utils/Hooks/SafeTransferFromHookMock.sol";
+import {SafeTransferFromHookMock} from "../utils/hooks/SafeTransferFromHookMock.sol";
 
 contract SafeTransferFromTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/SafeTransferFromHook.t.sol
+++ b/test/hooks/SafeTransferFromHook.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {SafeTransferFromHookMock} from "../utils/Hooks/SafeTransferFromHookMock.sol";
+
+contract SafeTransferFromTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+    SafeTransferFromHookMock hookMock;
+
+    function setUp() public {
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
+        hookMock = new SafeTransferFromHookMock();
+    }
+
+    function test_safeTransferFromHook() public {
+        assertEq(address(0), address(erc721Mock.safeTransferFromHook()));
+    }
+
+    function test_setSafeTransferFromHook() public {
+        assertEq(address(0), address(erc721Mock.safeTransferFromHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock.setSafeTransferFromHook(hookMock);
+        assertEq(address(hookMock), address(erc721Mock.safeTransferFromHook()));
+    }
+
+    function test_safeTransferFrom_WithData(
+        uint256 _mintQuantity,
+        uint256 _tokenId,
+        bytes memory data,
+        address buyer
+    ) public {
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_tokenId > 0);
+        vm.assume(_mintQuantity < 10_000);
+        vm.assume(_mintQuantity >= _tokenId);
+        vm.assume(buyer != address(0));
+
+        // Mint some tokens first
+        test_setSafeTransferFromHook();
+        erc721Mock.mint(buyer, _mintQuantity);
+
+        // Verify normal functionality
+        vm.prank(buyer);
+        erc721Mock.safeTransferFrom(
+            buyer,
+            DEFAULT_OWNER_ADDRESS,
+            _tokenId,
+            data
+        );
+        assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.ownerOf(_tokenId));
+
+        // Verify hook override
+        hookMock.setHooksEnabled(true);
+        vm.expectRevert(
+            SafeTransferFromHookMock.SafeTransferFromHook_Executed.selector
+        );
+        vm.prank(buyer);
+        erc721Mock.safeTransferFrom(
+            buyer,
+            DEFAULT_OWNER_ADDRESS,
+            _tokenId,
+            data
+        );
+    }
+
+    function test_safeTransferFrom_WithoutData(
+        uint256 _mintQuantity,
+        uint256 _tokenId
+    ) public {
+        vm.assume(_tokenId > 0);
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_mintQuantity < 10_000);
+        vm.assume(_mintQuantity >= _tokenId);
+
+        // Mint some tokens first
+        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+
+        // Verify normal functionality
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.safeTransferFrom(
+            DEFAULT_BUYER_ADDRESS,
+            DEFAULT_OWNER_ADDRESS,
+            _tokenId
+        );
+        assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.ownerOf(_tokenId));
+
+        // Verify hook override
+        hookMock.setHooksEnabled(true);
+        test_setSafeTransferFromHook();
+        vm.expectRevert(
+            SafeTransferFromHookMock.SafeTransferFromHook_Executed.selector
+        );
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.safeTransferFrom(
+            DEFAULT_BUYER_ADDRESS,
+            DEFAULT_OWNER_ADDRESS,
+            _tokenId
+        );
+    }
+}

--- a/test/hooks/SetApprovalForAllHook.t.sol
+++ b/test/hooks/SetApprovalForAllHook.t.sol
@@ -1,0 +1,60 @@
+// // SPDX-License-Identifier: MIT
+// pragma solidity ^0.8.15;
+
+// import {Vm} from "forge-std/Vm.sol";
+// import {DSTest} from "ds-test/test.sol";
+// import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+// import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+// import {SetApprovalForAllHookMock} from "../utils/Hooks/ApproveHookMock.sol";
+
+// contract SetApprovalForAllHookTest is DSTest {
+//     Vm public constant vm = Vm(HEVM_ADDRESS);
+//     address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+//     address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+//     ERC721ACHMock erc721Mock;
+//     SetApprovalForAllHookMock hookMock;
+
+//     function setUp() public {
+//         erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
+//         hookMock = new SetApprovalForAllHookMock();
+//     }
+
+//     function test_approveHook() public {
+//         assertEq(address(0), address(erc721Mock.approveHook()));
+//     }
+
+//     function test_setApprovalForAllHook() public {
+//         assertEq(address(0), address(erc721Mock.approveHook()));
+//         vm.prank(DEFAULT_OWNER_ADDRESS);
+//         erc721Mock.setApprovalForAllHook(hookMock);
+//         assertEq(address(hookMock), address(erc721Mock.setApprovalForAllHook()));
+//     }
+
+//     function test_setApprovalForAll(
+//         uint256 _mintQuantity,
+//         uint256 _tokenToApprove
+//     ) public {
+//         vm.assume(_mintQuantity > 0);
+//         vm.assume(_tokenToApprove > 0);
+//         vm.assume(_mintQuantity < 10_000);
+//         vm.assume(_tokenToApprove <= _mintQuantity);
+
+//         // Mint some tokens first
+//         erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+
+//         // Verify normal functionality
+//         assertEq(address(0), erc721Mock.getApproved(_tokenToApprove));
+//         vm.prank(DEFAULT_BUYER_ADDRESS);
+//         erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
+//         assertEq(
+//             DEFAULT_OWNER_ADDRESS,
+//             erc721Mock.getApproved(_tokenToApprove)
+//         );
+
+//         // Verify hook override
+//         // hookMock.setHooksEnabled(true);
+//         // vm.expectRevert(ERC721ACHMock.ApproveHook_Executed.selector);
+//         // vm.prank(DEFAULT_BUYER_ADDRESS);
+//         // erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
+//     }
+// }

--- a/test/hooks/SetApprovalForAllHook.t.sol
+++ b/test/hooks/SetApprovalForAllHook.t.sol
@@ -1,60 +1,66 @@
-// // SPDX-License-Identifier: MIT
-// pragma solidity ^0.8.15;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
 
-// import {Vm} from "forge-std/Vm.sol";
-// import {DSTest} from "ds-test/test.sol";
-// import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
-// import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-// import {SetApprovalForAllHookMock} from "../utils/Hooks/ApproveHookMock.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {SetApprovalForAllHookMock} from "../utils/Hooks/SetApprovalForAllHookMock.sol";
 
-// contract SetApprovalForAllHookTest is DSTest {
-//     Vm public constant vm = Vm(HEVM_ADDRESS);
-//     address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
-//     address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
-//     ERC721ACHMock erc721Mock;
-//     SetApprovalForAllHookMock hookMock;
+contract SetApprovalForAllHookTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+    SetApprovalForAllHookMock hookMock;
 
-//     function setUp() public {
-//         erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
-//         hookMock = new SetApprovalForAllHookMock();
-//     }
+    function setUp() public {
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
+        hookMock = new SetApprovalForAllHookMock();
+    }
 
-//     function test_approveHook() public {
-//         assertEq(address(0), address(erc721Mock.approveHook()));
-//     }
+    function test_setApprovalForAllHookHook() public {
+        assertEq(address(0), address(erc721Mock.setApprovalForAllHook()));
+    }
 
-//     function test_setApprovalForAllHook() public {
-//         assertEq(address(0), address(erc721Mock.approveHook()));
-//         vm.prank(DEFAULT_OWNER_ADDRESS);
-//         erc721Mock.setApprovalForAllHook(hookMock);
-//         assertEq(address(hookMock), address(erc721Mock.setApprovalForAllHook()));
-//     }
+    function test_setSetApprovalForAllHook() public {
+        assertEq(address(0), address(erc721Mock.setApprovalForAllHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock.setSetApprovalForAllHook(hookMock);
+        assertEq(
+            address(hookMock),
+            address(erc721Mock.setApprovalForAllHook())
+        );
+    }
 
-//     function test_setApprovalForAll(
-//         uint256 _mintQuantity,
-//         uint256 _tokenToApprove
-//     ) public {
-//         vm.assume(_mintQuantity > 0);
-//         vm.assume(_tokenToApprove > 0);
-//         vm.assume(_mintQuantity < 10_000);
-//         vm.assume(_tokenToApprove <= _mintQuantity);
+    function test_setApprovalForAll(uint256 _mintQuantity) public {
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_mintQuantity < 10_000);
 
-//         // Mint some tokens first
-//         erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+        // Mint some tokens first
+        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
 
-//         // Verify normal functionality
-//         assertEq(address(0), erc721Mock.getApproved(_tokenToApprove));
-//         vm.prank(DEFAULT_BUYER_ADDRESS);
-//         erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
-//         assertEq(
-//             DEFAULT_OWNER_ADDRESS,
-//             erc721Mock.getApproved(_tokenToApprove)
-//         );
+        // Verify normal functionality
+        assertTrue(
+            !erc721Mock.isApprovedForAll(
+                DEFAULT_BUYER_ADDRESS,
+                DEFAULT_OWNER_ADDRESS
+            )
+        );
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.setApprovalForAll(DEFAULT_OWNER_ADDRESS, true);
+        assertTrue(
+            erc721Mock.isApprovedForAll(
+                DEFAULT_BUYER_ADDRESS,
+                DEFAULT_OWNER_ADDRESS
+            )
+        );
 
-//         // Verify hook override
-//         // hookMock.setHooksEnabled(true);
-//         // vm.expectRevert(ERC721ACHMock.ApproveHook_Executed.selector);
-//         // vm.prank(DEFAULT_BUYER_ADDRESS);
-//         // erc721Mock.approve(DEFAULT_OWNER_ADDRESS, _tokenToApprove);
-//     }
-// }
+        // Verify hook override
+        test_setSetApprovalForAllHook();
+        hookMock.setHooksEnabled(true);
+        vm.expectRevert(ERC721ACHMock.SetApprovalForAllHook_Executed.selector);
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.setApprovalForAll(DEFAULT_OWNER_ADDRESS, true);
+    }
+}

--- a/test/hooks/SetApprovalForAllHook.t.sol
+++ b/test/hooks/SetApprovalForAllHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {SetApprovalForAllHookMock} from "../utils/Hooks/SetApprovalForAllHookMock.sol";
+import {SetApprovalForAllHookMock} from "../utils/hooks/SetApprovalForAllHookMock.sol";
 
 contract SetApprovalForAllHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/TransferFromHook.t.sol
+++ b/test/hooks/TransferFromHook.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {TransferFromHookMock} from "../utils/Hooks/TransferFromHookMock.sol";
+import {TransferFromHookMock} from "../utils/hooks/TransferFromHookMock.sol";
 
 contract TransferFromTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);

--- a/test/hooks/TransferFromHook.t.sol
+++ b/test/hooks/TransferFromHook.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {TransferFromHookMock} from "../utils/Hooks/TransferFromHookMock.sol";
+
+contract TransferFromTest is DSTest {
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0x111);
+    ERC721ACHMock erc721Mock;
+    TransferFromHookMock hookMock;
+
+    function setUp() public {
+        erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
+        hookMock = new TransferFromHookMock();
+    }
+
+    function test_transferFromHook() public {
+        assertEq(address(0), address(erc721Mock.transferFromHook()));
+    }
+
+    function test_setTransferFromHook() public {
+        assertEq(address(0), address(erc721Mock.transferFromHook()));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock.setTransferFromHook(hookMock);
+        assertEq(address(hookMock), address(erc721Mock.transferFromHook()));
+    }
+
+    function test_transferFrom(uint256 _mintQuantity, uint256 _tokenId) public {
+        vm.assume(_tokenId > 0);
+        vm.assume(_mintQuantity > 0);
+        vm.assume(_mintQuantity < 10_000);
+        vm.assume(_mintQuantity >= _tokenId);
+        test_setTransferFromHook();
+
+        // Mint some tokens first
+        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, _mintQuantity);
+
+        // Verify normal functionality
+        assertEq(DEFAULT_BUYER_ADDRESS, erc721Mock.ownerOf(_tokenId));
+        vm.prank(DEFAULT_BUYER_ADDRESS);
+        erc721Mock.transferFrom(
+            DEFAULT_BUYER_ADDRESS,
+            DEFAULT_OWNER_ADDRESS,
+            _tokenId
+        );
+        assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.ownerOf(_tokenId));
+
+        // Verify hook override
+        hookMock.setHooksEnabled(true);
+        vm.expectRevert(
+            TransferFromHookMock.TransferFromHook_Executed.selector
+        );
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        erc721Mock.transferFrom(
+            DEFAULT_OWNER_ADDRESS,
+            DEFAULT_BUYER_ADDRESS,
+            _tokenId
+        );
+    }
+}

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -70,12 +70,6 @@ contract ERC721ACHMock is ERC721ACH {
         hooksEnabled = _enabled;
     }
 
-    function _useOwnerOfHook(
-        uint256
-    ) internal view virtual override returns (bool) {
-        return hooksEnabled;
-    }
-
     function _useApproveHook(
         address,
         uint256

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -17,8 +17,6 @@ contract ERC721ACHMock is ERC721ACH {
     error SetApprovalForAllHook_Executed();
     /// @notice error to transferFrom approve hook was executed
     error TransferFromHook_Executed();
-    /// @notice error to safeTransferFrom approve hook was executed
-    error SafeTransferFromHook_Executed();
 
     function mint(address to, uint256 quantity) external {
         _mint(to, quantity);
@@ -57,16 +55,6 @@ contract ERC721ACHMock is ERC721ACH {
         uint256
     ) internal virtual override {
         revert TransferFromHook_Executed();
-    }
-
-    function _safeTransferFromHook(
-        address,
-        address,
-        address,
-        uint256,
-        bytes memory
-    ) internal virtual override {
-        revert SafeTransferFromHook_Executed();
     }
 
     /////////////////////////////////////////////////
@@ -108,16 +96,6 @@ contract ERC721ACHMock is ERC721ACH {
         address,
         address,
         uint256
-    ) internal view virtual override returns (bool) {
-        return hooksEnabled;
-    }
-
-    function _useSafeTransferFromHook(
-        address,
-        address,
-        address,
-        uint256,
-        bytes memory
     ) internal view virtual override returns (bool) {
         return hooksEnabled;
     }

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -30,30 +30,10 @@ contract ERC721ACHMock is ERC721ACH {
     }
 
     /////////////////////////////////////////////////
-    /// Hooks
-    /////////////////////////////////////////////////
-
-    function _setApprovalForAllHook(
-        address,
-        address,
-        bool
-    ) internal virtual override {
-        revert SetApprovalForAllHook_Executed();
-    }
-
-    /////////////////////////////////////////////////
     /// Enable Hooks
     /////////////////////////////////////////////////
     function setHooksEnabled(bool _enabled) public {
         hooksEnabled = _enabled;
-    }
-
-    function _useSetApprovalForAllHook(
-        address,
-        address,
-        bool
-    ) internal view virtual override returns (bool) {
-        return hooksEnabled;
     }
 
     function _useGetApprovedHook(

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -35,10 +35,6 @@ contract ERC721ACHMock is ERC721ACH {
     /// Hooks
     /////////////////////////////////////////////////
 
-    function _approveHook(address, uint256) internal virtual override {
-        revert ApproveHook_Executed();
-    }
-
     function _setApprovalForAllHook(
         address,
         address,
@@ -52,13 +48,6 @@ contract ERC721ACHMock is ERC721ACH {
     /////////////////////////////////////////////////
     function setHooksEnabled(bool _enabled) public {
         hooksEnabled = _enabled;
-    }
-
-    function _useApproveHook(
-        address,
-        uint256
-    ) internal view virtual override returns (bool) {
-        return hooksEnabled;
     }
 
     function _useSetApprovalForAllHook(

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -36,12 +36,6 @@ contract ERC721ACHMock is ERC721ACH {
         hooksEnabled = _enabled;
     }
 
-    function _useGetApprovedHook(
-        uint256
-    ) internal view virtual override returns (bool) {
-        return hooksEnabled;
-    }
-
     function _useIsApprovedForAllHook(
         address,
         address

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -4,9 +4,12 @@ pragma solidity ^0.8.15;
 import {ERC721ACH} from "../../src/ERC721ACH.sol";
 
 contract ERC721ACHMock is ERC721ACH {
-    constructor() ERC721ACH("ERC-721ACH Mock", "MOCK") {}
+    bool public hooksEnabled;
+    address public owner;
 
-    bool hooksEnabled;
+    constructor(address _owner) ERC721ACH("ERC-721ACH Mock", "MOCK") {
+        owner = _owner;
+    }
 
     /// @notice error to verify approve hook was executed
     error ApproveHook_Executed();
@@ -27,6 +30,9 @@ contract ERC721ACHMock is ERC721ACH {
 
     function _requireCallerIsContractOwner() internal view override(ERC721ACH) {
         // Derived contract's implementation here
+        if (msg.sender != owner) {
+            revert Access_OnlyOwner();
+        }
     }
 
     /////////////////////////////////////////////////

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -15,8 +15,6 @@ contract ERC721ACHMock is ERC721ACH {
     error ApproveHook_Executed();
     /// @notice error to verify setApprovalForAll hook was executed
     error SetApprovalForAllHook_Executed();
-    /// @notice error to transferFrom approve hook was executed
-    error TransferFromHook_Executed();
 
     function mint(address to, uint256 quantity) external {
         _mint(to, quantity);
@@ -47,14 +45,6 @@ contract ERC721ACHMock is ERC721ACH {
         bool
     ) internal virtual override {
         revert SetApprovalForAllHook_Executed();
-    }
-
-    function _transferFromHook(
-        address,
-        address,
-        uint256
-    ) internal virtual override {
-        revert TransferFromHook_Executed();
     }
 
     /////////////////////////////////////////////////
@@ -88,14 +78,6 @@ contract ERC721ACHMock is ERC721ACH {
     function _useIsApprovedForAllHook(
         address,
         address
-    ) internal view virtual override returns (bool) {
-        return hooksEnabled;
-    }
-
-    function _useTransferFromHook(
-        address,
-        address,
-        uint256
     ) internal view virtual override returns (bool) {
         return hooksEnabled;
     }

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -11,8 +11,6 @@ contract ERC721ACHMock is ERC721ACH {
         owner = _owner;
     }
 
-    /// @notice error to verify approve hook was executed
-    error ApproveHook_Executed();
     /// @notice error to verify setApprovalForAll hook was executed
     error SetApprovalForAllHook_Executed();
 

--- a/test/utils/ERC721ACHMock.sol
+++ b/test/utils/ERC721ACHMock.sol
@@ -70,12 +70,6 @@ contract ERC721ACHMock is ERC721ACH {
         hooksEnabled = _enabled;
     }
 
-    function _useBalanceOfHook(
-        address
-    ) internal view virtual override returns (bool) {
-        return hooksEnabled;
-    }
-
     function _useOwnerOfHook(
         uint256
     ) internal view virtual override returns (bool) {

--- a/test/utils/hooks/ApproveHookMock.sol
+++ b/test/utils/hooks/ApproveHookMock.sol
@@ -27,7 +27,7 @@ contract ApproveHookMock is IApproveHook {
     function approveOverrideHook(
         address,
         uint256
-    ) external view override returns (uint256) {
+    ) external pure override returns (uint256) {
         revert ApproveHook_Executed();
     }
 }

--- a/test/utils/hooks/ApproveHookMock.sol
+++ b/test/utils/hooks/ApproveHookMock.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.15;
 import {IApproveHook} from "../../../src/interfaces/IApproveHook.sol";
 
 contract ApproveHookMock is IApproveHook {
+    /// @notice approve hook was executed
+    error ApproveHook_Executed();
+
     bool public hooksEnabled;
 
     /// @notice toggle approve hook.
@@ -24,5 +27,7 @@ contract ApproveHookMock is IApproveHook {
     function approveOverrideHook(
         address,
         uint256
-    ) external view override returns (uint256) {}
+    ) external view override returns (uint256) {
+        revert ApproveHook_Executed();
+    }
 }

--- a/test/utils/hooks/ApproveHookMock.sol
+++ b/test/utils/hooks/ApproveHookMock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {IApproveHook} from "../../../src/interfaces/IApproveHook.sol";
+
+contract ApproveHookMock is IApproveHook {
+    bool public hooksEnabled;
+
+    /// @notice toggle approve hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the approve function should use hook.
+    /// @dev Returns whether or not to use the hook for approve function
+    function useApproveHook(
+        address,
+        uint256
+    ) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice approve Hook for custom implementation.
+    function approveOverrideHook(
+        address,
+        uint256
+    ) external view override returns (uint256) {}
+}

--- a/test/utils/hooks/BalanceOfHookMock.sol
+++ b/test/utils/hooks/BalanceOfHookMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {IBalanceOfHook} from "../../../src/interfaces/IBalanceOfHook.sol";
+
+contract BalanceOfHookMock is IBalanceOfHook {
+    bool hooksEnabled;
+
+    /// @notice toggle balanceOf hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the balanceOf function should use hook.
+    /// @dev Returns whether or not to use the hook for balanceOf function
+    function useBalanceOfHook(address) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice balanceOf Hook for custom implementation.
+    /// @param owner The address to query the balance of
+    /// @dev Returns the balance of the specified address
+    function balanceOfOverrideHook(
+        address owner
+    ) external view override returns (uint256) {}
+}

--- a/test/utils/hooks/BalanceOfHookMock.sol
+++ b/test/utils/hooks/BalanceOfHookMock.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.15;
 import {IBalanceOfHook} from "../../../src/interfaces/IBalanceOfHook.sol";
 
 contract BalanceOfHookMock is IBalanceOfHook {
-    bool hooksEnabled;
+    bool public hooksEnabled;
 
     /// @notice toggle balanceOf hook.
     function setHooksEnabled(bool _enabled) public {

--- a/test/utils/hooks/GetApprovedHookMock.sol
+++ b/test/utils/hooks/GetApprovedHookMock.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {IGetApprovedHook} from "../../../src/interfaces/IGetApprovedHook.sol";
+
+contract GetApprovedHookMock is IGetApprovedHook {
+    bool public hooksEnabled;
+
+    /// @notice toggle hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the function should use hook.
+    /// @dev Returns whether or not to use the hook
+    function useGetApprovedHook(uint256) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice Hook for custom implementation.
+    /// @dev Returns the balance of the specified address
+    function getApprovedOverrideHook(
+        uint256
+    ) external view override returns (address) {}
+}

--- a/test/utils/hooks/IsApprovedForAllHookMock.sol
+++ b/test/utils/hooks/IsApprovedForAllHookMock.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {IIsApprovedForAllHook} from "../../../src/interfaces/IIsApprovedForAllHook.sol";
+
+contract IsApprovedForAllHookMock is IIsApprovedForAllHook {
+    bool public hooksEnabled;
+
+    /// @notice toggle hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the function should use hook.
+    /// @dev Returns whether or not to use the hook
+    function useIsApprovedForAllHook(
+        address,
+        address
+    ) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice Hook for custom implementation.
+    /// @dev Returns the balance of the specified address
+    function isApprovedForAllOverrideHook(
+        address,
+        address
+    ) external view override returns (bool) {}
+}

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.15;
 import {IOwnerOfHook} from "../../../src/interfaces/IOwnerOfHook.sol";
 
 contract OwnerOfHookMock is IOwnerOfHook {
-    bool hooksEnabled;
+    bool public hooksEnabled;
 
     /// @notice toggle balanceOf hook.
     function setHooksEnabled(bool _enabled) public {

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {IOwnerOfHook} from "../../../src/interfaces/IOwnerOfHook.sol";
+
+contract OwnerOfHookMock is IOwnerOfHook {
+    bool hooksEnabled;
+
+    /// @notice toggle balanceOf hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the balanceOf function should use hook.
+    /// @dev Returns whether or not to use the hook for balanceOf function
+    function useOwnerOfHook(uint256) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice balanceOf Hook for custom implementation.
+    /// @dev Returns the balance of the specified address
+    function ownerOfOverrideHook(
+        uint256
+    ) external view override returns (address) {}
+}

--- a/test/utils/hooks/SafeTransferFromHookMock.sol
+++ b/test/utils/hooks/SafeTransferFromHookMock.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {ISafeTransferFromHook} from "../../../src/interfaces/ISafeTransferFromHook.sol";
+
+contract SafeTransferFromHookMock is ISafeTransferFromHook {
+    /// @notice error to safeTransferFrom approve hook was executed
+    error SafeTransferFromHook_Executed();
+
+    bool public hooksEnabled;
+
+    /// @notice toggle balanceOf hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the balanceOf function should use hook.
+    /// @dev Returns whether or not to use the hook for balanceOf function
+    function useSafeTransferFromHook(
+        address,
+        address,
+        address,
+        uint256,
+        bytes memory
+    ) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice balanceOf Hook for custom implementation.
+    /// @dev Returns the balance of the specified address
+    function safeTransferFromOverrideHook(
+        address,
+        address,
+        address,
+        uint256,
+        bytes memory
+    ) external pure override {
+        revert SafeTransferFromHook_Executed();
+    }
+}

--- a/test/utils/hooks/SetApprovalForAllHookMock.sol
+++ b/test/utils/hooks/SetApprovalForAllHookMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {ISetApprovalForAllHook} from "../../../src/interfaces/ISetApprovalForAllHook.sol";
+
+contract SetApprovalForAllHookMock is ISetApprovalForAllHook {
+    /// @notice hook was executed
+    error SetApprovalForAllHook_Executed();
+
+    bool public hooksEnabled;
+
+    /// @notice toggle approve hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the function should use hook.
+    /// @dev Returns whether or not to use the hook for approve function
+    function useSetApprovalForAllHook(
+        address,
+        address,
+        bool
+    ) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice approve Hook for custom implementation.
+    function setApprovalForAllOverrideHook(
+        address,
+        address,
+        bool
+    ) external pure override {
+        revert SetApprovalForAllHook_Executed();
+    }
+}

--- a/test/utils/hooks/TransferFromHookMock.sol
+++ b/test/utils/hooks/TransferFromHookMock.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {ITransferFromHook} from "../../../src/interfaces/ITransferFromHook.sol";
+
+contract TransferFromHookMock is ITransferFromHook {
+    /// @notice error to safeTransferFrom approve hook was executed
+    error TransferFromHook_Executed();
+
+    bool public hooksEnabled;
+
+    /// @notice toggle balanceOf hook.
+    function setHooksEnabled(bool _enabled) public {
+        hooksEnabled = _enabled;
+    }
+
+    /// @notice Check if the balanceOf function should use hook.
+    /// @dev Returns whether or not to use the hook for balanceOf function
+    function useTransferFromHook(
+        address,
+        address,
+        uint256
+    ) external view override returns (bool) {
+        return hooksEnabled;
+    }
+
+    /// @notice balanceOf Hook for custom implementation.
+    /// @dev Returns the balance of the specified address
+    function transferFromOverrideHook(
+        address,
+        address,
+        uint256
+    ) external pure override {
+        revert TransferFromHook_Executed();
+    }
+}


### PR DESCRIPTION
# ERC721H public variables
- `IBalanceOfHook public balanceOfHook`. ✨ 
- `IOwnerOfHook public ownerOfHook`. ✨ 
- `ISafeTransferFromHook public safeTransferFromHook`. ✨  
-  `ITransferFromHook public transferFromHook`. ✨ 
-  `IApproveHook public approveHook`. ✨ 
-  `ISetApprovalForAllHook public setApprovalForAllHook`. ✨ 
-  `IGetApprovedHook public getApprovedHook`. ✨ 
-  `IIsApprovedForAllHook public isApprovedForAllHook`. ✨ 
- question: How can we optimize `storage` of these variables? 💭 

### IERC721ACH
- `error Access_OnlyOwner`. ✨ 
- `event UpdatedHookBalanceOf`. ✨ 
- `event UpdatedHookOwnerOf`. ✨ 
- `event UpdatedHookSafeTransferFrom`. ✨ 
- `event UpdatedHookTransferFrom`. ✨ 
- `event UpdatedHookApprove`. ✨ 
- `event UpdatedHookSetApprovalForAll`. ✨ 
- `event UpdatedHookGetApproved`. ✨ 
- `event UpdatedHookIsApprovedForAll`. ✨ 
- `setBalanceOfHook`. ✨ 
- `setOwnerOfHook`. ✨ 
- `setSafeTransferFromHook`. ✨ 
- `setTransferFromHook`. ✨ 
- `setApproveHook`. ✨ 
- `setSetApprovalForAllHook`. ✨ 
- `setGetApprovedHook`. ✨ 
- `setIsApprovedForAllHook`. ✨ 

### Unit Tests
<img width="1286" alt="Screenshot 2023-07-23 at 9 58 53 PM" src="https://github.com/defientco/ERC721H/assets/23249402/b61ee7f7-ec9c-4f0f-b7ee-c41c5098d8e2">
