### PR TITLE
Sweets/cleanup

### DIFF
--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -103,7 +103,7 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
         IOwnerOfHook hook = IOwnerOfHook(hooks[HookType.OwnerOf]);
 
         if (address(hook) != address(0) && hook.useOwnerOfHook(tokenId)) {
-            return hook.ownerOfOverrideHook(tokenId);
+            return hook.ownerOfHook(tokenId);
         }
 
         return super.ownerOf(tokenId);

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -99,14 +99,13 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
      */
     function ownerOf(
         uint256 tokenId
-    ) public view virtual override returns (address) {
-        address owner;
+    ) public view virtual override returns (address owner) {
         bool runSuper;
 
-        IOwnerOfHook ownerOfHook = IOwnerOfHook(hooks[HookType.OwnerOf]);
+        IOwnerOfHook hook = IOwnerOfHook(hooks[HookType.OwnerOf]);
 
-        if (address(ownerOfHook) != address(0)) {
-            (owner, runSuper) = ownerOfHook.ownerOfHook(tokenId);
+        if (address(hook) != address(0)) {
+            (owner, runSuper) = hook.ownerOfHook(tokenId);
         } else {
             runSuper = true;
         }
@@ -114,8 +113,6 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
         if (runSuper) {
             owner = super.ownerOf(tokenId);
         }
-
-        return owner;
     }
 
     /**

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -100,13 +100,10 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
     function ownerOf(
         uint256 tokenId
     ) public view virtual override returns (address) {
-        IOwnerOfHook ownerOfHook = IOwnerOfHook(hooks[HookType.OwnerOf]);
+        IOwnerOfHook hook = IOwnerOfHook(hooks[HookType.OwnerOf]);
 
-        if (
-            address(ownerOfHook) != address(0) &&
-            ownerOfHook.useOwnerOfHook(tokenId)
-        ) {
-            return ownerOfHook.ownerOfOverrideHook(tokenId);
+        if (address(hook) != address(0) && hook.useOwnerOfHook(tokenId)) {
+            return hook.ownerOfOverrideHook(tokenId);
         }
 
         return super.ownerOf(tokenId);

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -83,19 +83,14 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
         uint256 quantity
     ) internal virtual override {
         super._afterTokenTransfers(from, to, startTokenId, quantity);
-        IAfterTokenTransfersHook afterTokenTransfersHook = IAfterTokenTransfersHook(
-                hooks[HookType.AfterTokenTransfers]
-            );
+        IAfterTokenTransfersHook hook = IAfterTokenTransfersHook(
+            hooks[HookType.AfterTokenTransfers]
+        );
         if (
-            address(afterTokenTransfersHook) != address(0) &&
-            afterTokenTransfersHook.useAfterTokenTransfersHook(
-                from,
-                to,
-                startTokenId,
-                quantity
-            )
+            address(hook) != address(0) &&
+            hook.useAfterTokenTransfersHook(from, to, startTokenId, quantity)
         ) {
-            afterTokenTransfersHook.afterTokenTransfersOverrideHook(
+            hook.afterTokenTransfersOverrideHook(
                 from,
                 to,
                 startTokenId,

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -91,7 +91,6 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
         }
     }
 
-<<<<<<< HEAD
     /**
      * @notice Returns the owner of the `tokenId` token.
      * @dev The owner of a token is also its approver by default.
@@ -101,35 +100,22 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
     function ownerOf(
         uint256 tokenId
     ) public view virtual override returns (address) {
-        IOwnerOfHook hook = IOwnerOfHook(hooks[HookType.OwnerOf]);
-
-        if (address(hook) != address(0) && hook.useOwnerOfHook(tokenId)) {
-            return hook.ownerOfHook(tokenId);
-        }
-
-        return super.ownerOf(tokenId);
-=======
-    function ownerOf(uint256 tokenId) public view virtual override returns (address) {
         address owner;
         bool runSuper;
 
         IOwnerOfHook ownerOfHook = IOwnerOfHook(hooks[HookType.OwnerOf]);
 
-        if (
-            address(ownerOfHook) != address(0) &&
-            ownerOfHook.useOwnerOfHook(tokenId)
-        ) {
-            (owner, runSuper) = ownerOfHook.ownerOfOverrideHook(tokenId);
+        if (address(ownerOfHook) != address(0)) {
+            (owner, runSuper) = ownerOfHook.ownerOfHook(tokenId);
         } else {
             runSuper = true;
         }
-        
+
         if (runSuper) {
             owner = super.ownerOf(tokenId);
         }
 
         return owner;
->>>>>>> fba41f638a62e122470d308bdb8723c7d1a31574
     }
 
     /**

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+import {IERC721ACH} from "./interfaces/IERC721ACH.sol";
 import {ERC721AC} from "ERC721C/erc721c/ERC721AC.sol";
 import {IERC721A} from "erc721a/contracts/IERC721A.sol";
 import {IBeforeTokenTransfersHook} from "./interfaces/IBeforeTokenTransfersHook.sol";
 import {IAfterTokenTransfersHook} from "./interfaces/IAfterTokenTransfersHook.sol";
 import {IOwnerOfHook} from "./interfaces/IOwnerOfHook.sol";
-import {IERC721ACH} from "./interfaces/IERC721ACH.sol";
 
 /**
  * @title ERC721ACH
@@ -16,7 +16,7 @@ import {IERC721ACH} from "./interfaces/IERC721ACH.sol";
  *  functions. Each hook type can be associated with a contract that implements the
  *  corresponding hook's logic. Only the contract owner can set or change these hooks.
  */
-contract ERC721ACH is ERC721AC, IERC721ACH {
+contract ERC721ACH is IERC721ACH, ERC721AC {
     /**
      * @dev This mapping associates hook types with their corresponding contract addresses.
      * Each hook type can be associated with a contract that implements the hook's logic.

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -101,7 +101,6 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
         uint256 tokenId
     ) public view virtual override returns (address owner) {
         bool runSuper;
-
         IOwnerOfHook hook = IOwnerOfHook(hooks[HookType.OwnerOf]);
 
         if (address(hook) != address(0)) {

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -86,16 +86,8 @@ contract ERC721ACH is IERC721ACH, ERC721AC {
         IAfterTokenTransfersHook hook = IAfterTokenTransfersHook(
             hooks[HookType.AfterTokenTransfers]
         );
-        if (
-            address(hook) != address(0) &&
-            hook.useAfterTokenTransfersHook(from, to, startTokenId, quantity)
-        ) {
-            hook.afterTokenTransfersOverrideHook(
-                from,
-                to,
-                startTokenId,
-                quantity
-            );
+        if (address(hook) != address(0)) {
+            hook.afterTokenTransfersHook(from, to, startTokenId, quantity);
         }
     }
 

--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -11,26 +11,24 @@ import {IERC721ACH} from "./interfaces/IERC721ACH.sol";
 /**
  * @title ERC721ACH
  * @author Cre8ors Inc.
- * @notice Extends Limit Break's ERC721-AC implementation with Hook functionality, which
- *  allows the contract owner to override hooks associated with core ERC721 functions.
+ * @notice This contract extends Limit Break's ERC721-AC implementation with hook functionality.
+ *  It allows the contract owner to set hooks that modify the behavior of core ERC721
+ *  functions. Each hook type can be associated with a contract that implements the
+ *  corresponding hook's logic. Only the contract owner can set or change these hooks.
  */
 contract ERC721ACH is ERC721AC, IERC721ACH {
-    
-
     /**
-    * @dev Mapping of hook types to their respective contract addresses.
-    * Each hook type can be associated with a contract that implements the hook's logic.
-    * Only the contract owner can set or update these hooks.
-    */
+     * @dev This mapping associates hook types with their corresponding contract addresses.
+     * Each hook type can be associated with a contract that implements the hook's logic.
+     * Only the contract owner can set or change these hooks.
+     */
     mapping(HookType => address) public hooks;
 
-
-    event UpdatedHook(address indexed setter, HookType hookType, address indexed hookAddress);
-
-
-    /// @notice Contract constructor
-    /// @param _contractName The name for the token contract
-    /// @param _contractSymbol The symbol for the token contract
+    /**
+     * @dev Contract constructor.
+     * @param _contractName The name of the token contract.
+     * @param _contractSymbol The symbol of the token contract.
+     */
     constructor(
         string memory _contractName,
         string memory _contractSymbol
@@ -47,9 +45,14 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     /// ERC721 overrides
     /////////////////////////////////////////////////
 
-
-
-    /// TODO
+    /**
+     * @notice Before token transfer hook. This function is called before any token transfer.
+     * This includes minting and burning.
+     * @param from The source address.
+     * @param to The destination address.
+     * @param startTokenId The ID of the first token to be transferred.
+     * @param quantity The number of tokens to be transferred.
+     */
     function _beforeTokenTransfers(
         address from,
         address to,
@@ -57,33 +60,40 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
         uint256 quantity
     ) internal virtual override {
         super._beforeTokenTransfers(from, to, startTokenId, quantity);
-        IBeforeTokenTransfersHook beforeTokenTransfersHook = IBeforeTokenTransfersHook(hooks[HookType.BeforeTokenTransfers]);
-        if (
-            address(beforeTokenTransfersHook) != address(0) &&
-            beforeTokenTransfersHook.useBeforeTokenTransfersHook(from, to, startTokenId, quantity)
-        ) {
-            beforeTokenTransfersHook.beforeTokenTransfersOverrideHook(
-                from,
-                to,
-                startTokenId,
-                quantity
-            );
-        } 
+        IBeforeTokenTransfersHook hook = IBeforeTokenTransfersHook(
+            hooks[HookType.BeforeTokenTransfers]
+        );
+        if (address(hook) != address(0)) {
+            hook.beforeTokenTransfersHook(from, to, startTokenId, quantity);
+        }
     }
 
-    /// TODO
+    /**
+     * @notice After token transfer hook. This function is called after any token transfer.
+     * This includes minting and burning.
+     * @param from The source address.
+     * @param to The destination address.
+     * @param startTokenId The ID of the first token to be transferred.
+     * @param quantity The number of tokens to be transferred.
+     */
     function _afterTokenTransfers(
         address from,
         address to,
         uint256 startTokenId,
         uint256 quantity
     ) internal virtual override {
-
         super._afterTokenTransfers(from, to, startTokenId, quantity);
-        IAfterTokenTransfersHook afterTokenTransfersHook = IAfterTokenTransfersHook(hooks[HookType.AfterTokenTransfers]);
+        IAfterTokenTransfersHook afterTokenTransfersHook = IAfterTokenTransfersHook(
+                hooks[HookType.AfterTokenTransfers]
+            );
         if (
             address(afterTokenTransfersHook) != address(0) &&
-            afterTokenTransfersHook.useAfterTokenTransfersHook(from, to, startTokenId, quantity)
+            afterTokenTransfersHook.useAfterTokenTransfersHook(
+                from,
+                to,
+                startTokenId,
+                quantity
+            )
         ) {
             afterTokenTransfersHook.afterTokenTransfersOverrideHook(
                 from,
@@ -91,11 +101,18 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
                 startTokenId,
                 quantity
             );
-        } 
+        }
     }
 
-    function ownerOf(uint256 tokenId) public view virtual override returns (address) {
-        
+    /**
+     * @notice Returns the owner of the `tokenId` token.
+     * @dev The owner of a token is also its approver by default.
+     * @param tokenId The ID of the token to query.
+     * @return owner of the `tokenId` token.
+     */
+    function ownerOf(
+        uint256 tokenId
+    ) public view virtual override returns (address) {
         IOwnerOfHook ownerOfHook = IOwnerOfHook(hooks[HookType.OwnerOf]);
 
         if (
@@ -103,17 +120,16 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
             ownerOfHook.useOwnerOfHook(tokenId)
         ) {
             return ownerOfHook.ownerOfOverrideHook(tokenId);
-        } 
-        
+        }
+
         return super.ownerOf(tokenId);
     }
 
-
     /**
-        * @notice Returns the contract address for a specified hook type.
-        * @param hookType The type of hook to retrieve, as defined in the HookType enum.
-        * @return The address of the contract implementing the hook interface.
-    */
+     * @notice Returns the address of the contract that implements the logic for the given hook type.
+     * @param hookType The type of the hook to query.
+     * @return address of the contract that implements the hook's logic.
+     */
     function getHook(HookType hookType) external view returns (address) {
         return hooks[hookType];
     }
@@ -122,7 +138,10 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     /// ERC721C Override
     /////////////////////////////////////////////////
 
-    /// @notice Override the function to throw if caller is not contract owner
+    /**
+     * @notice This internal function is used to ensure that the caller is the contract owner.
+     * @dev Throws if called by any account other than the owner.
+     */
     function _requireCallerIsContractOwner() internal view virtual override {}
 
     /////////////////////////////////////////////////
@@ -130,18 +149,24 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     /////////////////////////////////////////////////
 
     /**
-        * @notice Sets the contract address for a specified hook type.
-        * @param hookType The type of hook to set, as defined in the HookType enum.
-        * @param hookAddress The address of the contract implementing the hook interface.
-    */
-    function setHook(HookType hookType, address hookAddress) external virtual onlyOwner {
+     * @notice Updates the contract address for a specific hook type.
+     * @dev Throws if called by any account other than the owner.
+     * Emits a {UpdatedHook} event.
+     * @param hookType The type of the hook to set.
+     * @param hookAddress The address of the contract that implements the hook's logic.
+     */
+    function setHook(
+        HookType hookType,
+        address hookAddress
+    ) external virtual onlyOwner {
         hooks[hookType] = hookAddress;
         emit UpdatedHook(msg.sender, hookType, hookAddress);
     }
 
-
-
-    /// TODO
+    /**
+     * @notice This modifier checks if the caller is the contract owner.
+     * @dev Throws if called by any account other than the owner.
+     */
     modifier onlyOwner() {
         _requireCallerIsContractOwner();
 

--- a/src/interfaces/IAfterTokenTransfersHook.sol
+++ b/src/interfaces/IAfterTokenTransfersHook.sol
@@ -5,12 +5,11 @@ pragma solidity ^0.8.15;
 /// @dev Interface that defines hooks to be executed After token transfers.
 interface IAfterTokenTransfersHook {
     /**
-        @notice Emitted when the after token transfers hook is used.
-        @param from Address from which the tokens are being transferred.
-        @param to Address to which the tokens are being transferred.
-        @param startTokenId The starting ID of the tokens being transferred.
-        @param quantity The number of tokens being transferred.
-    
+     * @notice Emitted when the after token transfers hook is used.
+     * @param from Address from which the tokens are being transferred.
+     * @param to Address to which the tokens are being transferred.
+     * @param startTokenId The starting ID of the tokens being transferred.
+     * @param quantity The number of tokens being transferred.
      */
     event AfterTokenTransfersHookUsed(
         address from,
@@ -20,12 +19,11 @@ interface IAfterTokenTransfersHook {
     );
 
     /**
-        @notice Provides a custom implementation for the token transfers process.
-        @param from Address from which the tokens are being transferred.
-        @param to Address to which the tokens are being transferred.
-        @param startTokenId The starting ID of the tokens being transferred.
-        @param quantity The number of tokens being transferred.
-            
+     * @notice Provides a custom implementation for the token transfers process.
+     * @param from Address from which the tokens are being transferred.
+     * @param to Address to which the tokens are being transferred.
+     * @param startTokenId The starting ID of the tokens being transferred.
+     * @param quantity The number of tokens being transferred.
      */
     function afterTokenTransfersHook(
         address from,

--- a/src/interfaces/IAfterTokenTransfersHook.sol
+++ b/src/interfaces/IAfterTokenTransfersHook.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.15;
 /// @title IAfterTokenTransfersHook
 /// @dev Interface that defines hooks to be executed After token transfers.
 interface IAfterTokenTransfersHook {
-
     /**
         @notice Emitted when the after token transfers hook is used.
         @param from Address from which the tokens are being transferred.
@@ -21,22 +20,6 @@ interface IAfterTokenTransfersHook {
     );
 
     /**
-        @notice Checks if the token transfers function should use the custom hook.
-        @param from Address from which the tokens are being transferred.
-        @param to Address to which the tokens are being transferred.
-        @param startTokenId The starting ID of the tokens being transferred.
-        @param quantity The number of tokens being transferred.
-        @return A boolean indicating whether or not to use the custom hook for the token transfers function.
-        
-     */
-    function useAfterTokenTransfersHook(
-        address from,
-        address to,
-        uint256 startTokenId,
-        uint256 quantity
-    ) external view returns (bool);
-
-    /**
         @notice Provides a custom implementation for the token transfers process.
         @param from Address from which the tokens are being transferred.
         @param to Address to which the tokens are being transferred.
@@ -44,7 +27,7 @@ interface IAfterTokenTransfersHook {
         @param quantity The number of tokens being transferred.
             
      */
-    function afterTokenTransfersOverrideHook(
+    function afterTokenTransfersHook(
         address from,
         address to,
         uint256 startTokenId,

--- a/src/interfaces/IBeforeTokenTransfersHook.sol
+++ b/src/interfaces/IBeforeTokenTransfersHook.sol
@@ -4,14 +4,12 @@ pragma solidity ^0.8.15;
 /// @title IBeforeTokenTransfersHook
 /// @dev Interface that defines hooks to be executed before token transfers.
 interface IBeforeTokenTransfersHook {
-
     /**
-        @notice Emitted when the before token transfers hook is used.
-        @param from Address from which the tokens are being transferred.
-        @param to Address to which the tokens are being transferred.
-        @param startTokenId The starting ID of the tokens being transferred.
-        @param quantity The number of tokens being transferred.
-    
+     * @notice Emitted when the before token transfers hook is used.
+     * @param from Address from which the tokens are being transferred.
+     * @param to Address to which the tokens are being transferred.
+     * @param startTokenId The starting ID of the tokens being transferred.
+     * @param quantity The number of tokens being transferred.
      */
     event BeforeTokenTransfersHookUsed(
         address from,
@@ -21,30 +19,13 @@ interface IBeforeTokenTransfersHook {
     );
 
     /**
-        @notice Checks if the token transfers function should use the custom hook.
-        @param from Address from which the tokens are being transferred.
-        @param to Address to which the tokens are being transferred.
-        @param startTokenId The starting ID of the tokens being transferred.
-        @param quantity The number of tokens being transferred.
-        @return A boolean indicating whether or not to use the custom hook for the token transfers function.
-        
+     * @notice Provides a custom implementation for the token transfers process.
+     * @param from Address from which the tokens are being transferred.
+     * @param to Address to which the tokens are being transferred.
+     * @param startTokenId The starting ID of the tokens being transferred.
+     * @param quantity The number of tokens being transferred.
      */
-    function useBeforeTokenTransfersHook(
-        address from,
-        address to,
-        uint256 startTokenId,
-        uint256 quantity
-    ) external view returns (bool);
-
-    /**
-        @notice Provides a custom implementation for the token transfers process.
-        @param from Address from which the tokens are being transferred.
-        @param to Address to which the tokens are being transferred.
-        @param startTokenId The starting ID of the tokens being transferred.
-        @param quantity The number of tokens being transferred.
-            
-     */
-    function beforeTokenTransfersOverrideHook(
+    function beforeTokenTransfersHook(
         address from,
         address to,
         uint256 startTokenId,

--- a/src/interfaces/IERC721ACH.sol
+++ b/src/interfaces/IERC721ACH.sol
@@ -1,23 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-
 interface IERC721ACH {
-    
-
     /**
-        * @dev Enumerated list of all available hook types for the ERC721ACH contract.
-    */
-     enum HookType {
-        
+     * @dev Enumerated list of all available hook types for the ERC721ACH contract.
+     */
+    enum HookType {
         /// @notice Hook for custom logic before a token transfer occurs.
         BeforeTokenTransfers,
         /// @notice Hook for custom logic after a token transfer occurs.
         AfterTokenTransfers,
         /// @notice Hook for custom logic for ownerOf() function.
-        OwnerOf  
+        OwnerOf
     }
 
+    /**
+     * @notice An event that gets emitted when a hook is updated.
+     * @param setter The address that set the hook.
+     * @param hookType The type of the hook that was set.
+     * @param hookAddress The address of the contract that implements the hook.
+     */
+    event UpdatedHook(
+        address indexed setter,
+        HookType hookType,
+        address indexed hookAddress
+    );
 
     /**
      * @notice Sets the contract address for a specified hook type.
@@ -32,5 +39,4 @@ interface IERC721ACH {
      * @return The address of the contract implementing the hook interface.
      */
     function getHook(HookType hookType) external view returns (address);
-
 }

--- a/src/interfaces/IOwnerOfHook.sol
+++ b/src/interfaces/IOwnerOfHook.sol
@@ -12,13 +12,6 @@ interface IOwnerOfHook {
     event OwnerOfHookUsed(uint256 tokenId, address owner);
 
     /**
-     * @notice Checks if the owner retrieval function should use the custom hook.
-     * @param tokenId The ID of the token whose owner is being retrieved.
-     * @return boolean indicating whether or not to use the custom hook for the owner retrieval function.
-     */
-    function useOwnerOfHook(uint256 tokenId) external view returns (bool);
-
-    /**
      * @notice Provides a custom implementation for the owner retrieval process.
      * @param tokenId The ID of the token whose owner is being retrieved.
      * @return A tuple with The address of the owner of the token and A bool flag whether to run `super.ownerOf` or not

--- a/src/interfaces/IOwnerOfHook.sol
+++ b/src/interfaces/IOwnerOfHook.sol
@@ -5,23 +5,23 @@ pragma solidity ^0.8.15;
 /// @dev Interface that defines hooks for retrieving the owner of a token.
 interface IOwnerOfHook {
     /**
-        @notice Emitted when the owner of hook is used.
-        @param tokenId The ID of the token whose owner is being retrieved.
-        @param owner The address of the owner of the token.
+     * @notice Emitted when the owner of hook is used.
+     * @param tokenId The ID of the token whose owner is being retrieved.
+     * @param owner The address of the owner of the token.
      */
     event OwnerOfHookUsed(uint256 tokenId, address owner);
 
     /**
-        @notice Checks if the owner retrieval function should use the custom hook.
-        @param tokenId The ID of the token whose owner is being retrieved.
-        @return A boolean indicating whether or not to use the custom hook for the owner retrieval function.
+     * @notice Checks if the owner retrieval function should use the custom hook.
+     * @param tokenId The ID of the token whose owner is being retrieved.
+     * @return boolean indicating whether or not to use the custom hook for the owner retrieval function.
      */
     function useOwnerOfHook(uint256 tokenId) external view returns (bool);
 
     /**
-        @notice Provides a custom implementation for the owner retrieval process.
-        @param tokenId The ID of the token whose owner is being retrieved.
-        @return The address of the owner of the token.
+     * @notice Provides a custom implementation for the owner retrieval process.
+     * @param tokenId The ID of the token whose owner is being retrieved.
+     * @return address of the owner of the token.
      */
     function ownerOfHook(uint256 tokenId) external view returns (address);
 }

--- a/src/interfaces/IOwnerOfHook.sol
+++ b/src/interfaces/IOwnerOfHook.sol
@@ -4,32 +4,24 @@ pragma solidity ^0.8.15;
 /// @title IOwnerOfHook
 /// @dev Interface that defines hooks for retrieving the owner of a token.
 interface IOwnerOfHook {
-
     /**
         @notice Emitted when the owner of hook is used.
         @param tokenId The ID of the token whose owner is being retrieved.
         @param owner The address of the owner of the token.
      */
-    event OwnerOfHookUsed(
-        uint256 tokenId,
-        address owner
-    );
+    event OwnerOfHookUsed(uint256 tokenId, address owner);
 
     /**
         @notice Checks if the owner retrieval function should use the custom hook.
         @param tokenId The ID of the token whose owner is being retrieved.
         @return A boolean indicating whether or not to use the custom hook for the owner retrieval function.
      */
-    function useOwnerOfHook(
-        uint256 tokenId
-    ) external view returns (bool);
+    function useOwnerOfHook(uint256 tokenId) external view returns (bool);
 
     /**
         @notice Provides a custom implementation for the owner retrieval process.
         @param tokenId The ID of the token whose owner is being retrieved.
         @return The address of the owner of the token.
      */
-    function ownerOfOverrideHook(
-        uint256 tokenId
-    ) external view returns (address);
+    function ownerOfHook(uint256 tokenId) external view returns (address);
 }

--- a/test/hooks/AfterTokenTransfers.t.sol
+++ b/test/hooks/AfterTokenTransfers.t.sol
@@ -33,13 +33,8 @@ contract AfterTokenTransfersHookTest is DSTest, HookUtils {
         vm.expectRevert();
         erc721Mock.setHook(AfterTokenTransfers, address(hookMock));
 
-        vm.prank(DEFAULT_OWNER_ADDRESS);
-        erc721Mock.setHook(AfterTokenTransfers, address(hookMock));
-
-        assertEq(
-            address(hookMock),
-            address(erc721Mock.getHook(AfterTokenTransfers))
-        );
+        //  Verify Success
+        _setHook(address(erc721Mock), AfterTokenTransfers, address(hookMock));
     }
 
     function test_afterTokenTransfersHook(
@@ -74,6 +69,28 @@ contract AfterTokenTransfersHookTest is DSTest, HookUtils {
             AfterTokenTransfersHookMock
                 .AfterTokenTransfersHook_Executed
                 .selector
+        );
+    }
+
+    function test_turn_off_hook(
+        address _firstOwner,
+        address _secondOwner,
+        uint256 startTokenId,
+        uint256 quantity
+    ) public {
+        test_afterTokenTransfersHook(
+            _firstOwner,
+            _secondOwner,
+            startTokenId,
+            quantity
+        );
+
+        _setHook(address(erc721Mock), AfterTokenTransfers, address(0));
+        _assertNormalTransfer(
+            address(erc721Mock),
+            _secondOwner,
+            _firstOwner,
+            startTokenId
         );
     }
 }

--- a/test/hooks/AfterTokenTransfers.t.sol
+++ b/test/hooks/AfterTokenTransfers.t.sol
@@ -9,7 +9,6 @@ import {AfterTokenTransfersHookMock} from "../utils/hooks/AfterTokenTransfersHoo
 
 import {IERC721ACH} from "../../src/interfaces/IERC721ACH.sol";
 
-
 contract AfterTokenTransfersHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);
     address public constant DEFAULT_OWNER_ADDRESS = address(0xC0FFEE);
@@ -17,8 +16,8 @@ contract AfterTokenTransfersHookTest is DSTest {
     ERC721ACHMock erc721Mock;
     AfterTokenTransfersHookMock hookMock;
 
-    IERC721ACH.HookType constant AfterTokenTransfers = IERC721ACH.HookType.AfterTokenTransfers;
-
+    IERC721ACH.HookType constant AfterTokenTransfers =
+        IERC721ACH.HookType.AfterTokenTransfers;
 
     function setUp() public {
         erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
@@ -32,17 +31,20 @@ contract AfterTokenTransfersHookTest is DSTest {
     function test_setAfterTokenTransfersHook() public {
         assertEq(address(0), address(erc721Mock.getHook(AfterTokenTransfers)));
 
-        // calling an admin function without being the contract owner should revert       
+        // calling an admin function without being the contract owner should revert
         vm.expectRevert();
         erc721Mock.setHook(AfterTokenTransfers, address(hookMock));
-        
+
         vm.prank(DEFAULT_OWNER_ADDRESS);
         erc721Mock.setHook(AfterTokenTransfers, address(hookMock));
 
-        assertEq(address(hookMock), address(erc721Mock.getHook(AfterTokenTransfers)));
+        assertEq(
+            address(hookMock),
+            address(erc721Mock.getHook(AfterTokenTransfers))
+        );
     }
 
-     function test_afterTokenTransfersHook(
+    function test_afterTokenTransfersHook(
         uint256 startTokenId,
         uint256 quantity
     ) public {
@@ -50,13 +52,10 @@ contract AfterTokenTransfersHookTest is DSTest {
         vm.assume(startTokenId > 0);
         vm.assume(quantity < 10_000);
         vm.assume(quantity >= startTokenId);
-       
 
         // Mint some tokens first
-        test_setAfterTokenTransfersHook();
         erc721Mock.mint(DEFAULT_BUYER_ADDRESS, quantity);
 
-        
         vm.prank(DEFAULT_BUYER_ADDRESS);
         erc721Mock.transferFrom(
             DEFAULT_BUYER_ADDRESS,
@@ -67,9 +66,13 @@ contract AfterTokenTransfersHookTest is DSTest {
         assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.ownerOf(startTokenId));
 
         // Verify hook override
+        test_setAfterTokenTransfersHook();
+
         hookMock.setHooksEnabled(true);
         vm.expectRevert(
-            AfterTokenTransfersHookMock.AfterTokenTransfersHook_Executed.selector
+            AfterTokenTransfersHookMock
+                .AfterTokenTransfersHook_Executed
+                .selector
         );
         vm.prank(DEFAULT_OWNER_ADDRESS);
         erc721Mock.transferFrom(
@@ -77,11 +80,5 @@ contract AfterTokenTransfersHookTest is DSTest {
             DEFAULT_BUYER_ADDRESS,
             startTokenId
         );
-
-
     }
-
-
-
-
 }

--- a/test/hooks/BeforeTokenTransfers.t.sol
+++ b/test/hooks/BeforeTokenTransfers.t.sol
@@ -8,7 +8,6 @@ import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
 import {BeforeTokenTransfersHookMock} from "../utils/hooks/BeforeTokenTransfersHookMock.sol";
 import {IERC721ACH} from "../../src/interfaces/IERC721ACH.sol";
 
-
 contract BeforeTokenTransfersHookTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);
     address public constant DEFAULT_OWNER_ADDRESS = address(0xC0FFEE);
@@ -16,30 +15,36 @@ contract BeforeTokenTransfersHookTest is DSTest {
     ERC721ACHMock erc721Mock;
     BeforeTokenTransfersHookMock hookMock;
 
-    IERC721ACH.HookType constant BeforeTokenTransfers = IERC721ACH.HookType.BeforeTokenTransfers;
+    IERC721ACH.HookType constant BeforeTokenTransfers =
+        IERC721ACH.HookType.BeforeTokenTransfers;
 
     function setUp() public {
         erc721Mock = new ERC721ACHMock(DEFAULT_OWNER_ADDRESS);
         hookMock = new BeforeTokenTransfersHookMock();
     }
 
-    function test_beforeTokenTransfersHook() public {
+    function test_getHook_BeforeTokenTransfers() public {
         assertEq(address(0), address(erc721Mock.getHook(BeforeTokenTransfers)));
     }
 
     function test_setBeforeTokenTransfersHook() public {
         assertEq(address(0), address(erc721Mock.getHook(BeforeTokenTransfers)));
 
-        // calling an admin function without being the contract owner should revert       
+        // calling an admin function without being the contract owner should revert
         vm.expectRevert();
         erc721Mock.setHook(BeforeTokenTransfers, address(hookMock));
-        
+
         vm.prank(DEFAULT_OWNER_ADDRESS);
         erc721Mock.setHook(BeforeTokenTransfers, address(hookMock));
-        assertEq(address(hookMock), address(erc721Mock.getHook(BeforeTokenTransfers)));
+        assertEq(
+            address(hookMock),
+            address(erc721Mock.getHook(BeforeTokenTransfers))
+        );
     }
 
     function test_beforeTokenTransfersHook(
+        address _firstOwner,
+        address _secondOwner,
         uint256 startTokenId,
         uint256 quantity
     ) public {
@@ -47,37 +52,47 @@ contract BeforeTokenTransfersHookTest is DSTest {
         vm.assume(startTokenId > 0);
         vm.assume(quantity < 10_000);
         vm.assume(quantity >= startTokenId);
-       
+        _assumeNotBurn(_firstOwner);
 
         // Mint some tokens first
-        test_setBeforeTokenTransfersHook();
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, quantity);
-
-        
-        vm.prank(DEFAULT_BUYER_ADDRESS);
-        erc721Mock.transferFrom(
-            DEFAULT_BUYER_ADDRESS,
-            DEFAULT_OWNER_ADDRESS,
-            startTokenId
-        );
-
-        assertEq(DEFAULT_OWNER_ADDRESS, erc721Mock.ownerOf(startTokenId));
+        erc721Mock.mint(_firstOwner, quantity);
+        _assertNormalTransfer(_firstOwner, _secondOwner, startTokenId);
 
         // Verify hook override
-        hookMock.setHooksEnabled(true);
-        vm.expectRevert(
-            BeforeTokenTransfersHookMock.BeforeTokenTransfersHook_Executed.selector
-        );
-        vm.prank(DEFAULT_OWNER_ADDRESS);
-        erc721Mock.transferFrom(
-            DEFAULT_OWNER_ADDRESS,
-            DEFAULT_BUYER_ADDRESS,
-            startTokenId
-        );
-
-
+        test_setBeforeTokenTransfersHook();
+        _assertHookRevert(_secondOwner, _firstOwner, startTokenId);
     }
 
-    
+    function _assumeNotBurn(address _wallet) internal {
+        vm.assume(_wallet != address(0));
+    }
 
+    function _assertNormalTransfer(
+        address _from,
+        address _to,
+        uint256 _tokenId
+    ) public {
+        vm.prank(_from);
+        erc721Mock.transferFrom(_from, _to, _tokenId);
+
+        _assertOwner(_to, _tokenId);
+    }
+
+    function _assertOwner(address _owner, uint256 _token) internal {
+        assertEq(_owner, erc721Mock.ownerOf(_token));
+    }
+
+    function _assertHookRevert(
+        address _from,
+        address _to,
+        uint256 _tokenId
+    ) internal {
+        vm.prank(_from);
+        vm.expectRevert(
+            BeforeTokenTransfersHookMock
+                .BeforeTokenTransfersHook_Executed
+                .selector
+        );
+        erc721Mock.transferFrom(_from, _to, _tokenId);
+    }
 }

--- a/test/hooks/BeforeTokenTransfers.t.sol
+++ b/test/hooks/BeforeTokenTransfers.t.sol
@@ -63,7 +63,7 @@ contract BeforeTokenTransfersHookTest is DSTest {
         _assertHookRevert(_secondOwner, _firstOwner, startTokenId);
     }
 
-    function _assumeNotBurn(address _wallet) internal {
+    function _assumeNotBurn(address _wallet) internal pure {
         vm.assume(_wallet != address(0));
     }
 

--- a/test/hooks/BeforeTokenTransfers.t.sol
+++ b/test/hooks/BeforeTokenTransfers.t.sol
@@ -48,11 +48,12 @@ contract BeforeTokenTransfersHookTest is DSTest {
         uint256 startTokenId,
         uint256 quantity
     ) public {
-        vm.assume(quantity > 0);
-        vm.assume(startTokenId > 0);
+        _assumeGtZero(quantity);
+        _assumeGtZero(startTokenId);
         vm.assume(quantity < 10_000);
         vm.assume(quantity >= startTokenId);
         _assumeNotBurn(_firstOwner);
+        _assumeNotBurn(_secondOwner);
 
         // Mint some tokens first
         erc721Mock.mint(_firstOwner, quantity);
@@ -65,6 +66,10 @@ contract BeforeTokenTransfersHookTest is DSTest {
 
     function _assumeNotBurn(address _wallet) internal pure {
         vm.assume(_wallet != address(0));
+    }
+
+    function _assumeGtZero(uint256 _num) internal pure {
+        vm.assume(_num > 0);
     }
 
     function _assertNormalTransfer(

--- a/test/hooks/BeforeTokenTransfers.t.sol
+++ b/test/hooks/BeforeTokenTransfers.t.sol
@@ -14,7 +14,6 @@ contract BeforeTokenTransfersHookTest is DSTest {
     address public constant DEFAULT_BUYER_ADDRESS = address(0xBABE);
     ERC721ACHMock erc721Mock;
     BeforeTokenTransfersHookMock hookMock;
-
     IERC721ACH.HookType constant BeforeTokenTransfers =
         IERC721ACH.HookType.BeforeTokenTransfers;
 

--- a/test/hooks/BeforeTokenTransfers.t.sol
+++ b/test/hooks/BeforeTokenTransfers.t.sol
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
 import {BeforeTokenTransfersHookMock} from "../utils/hooks/BeforeTokenTransfersHookMock.sol";
+import {HookUtils} from "../utils/HookUtils.sol";
 import {IERC721ACH} from "../../src/interfaces/IERC721ACH.sol";
 
-contract BeforeTokenTransfersHookTest is DSTest {
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-    address public constant DEFAULT_OWNER_ADDRESS = address(0xC0FFEE);
-    address public constant DEFAULT_BUYER_ADDRESS = address(0xBABE);
+contract BeforeTokenTransfersHookTest is DSTest, HookUtils {
     ERC721ACHMock erc721Mock;
     BeforeTokenTransfersHookMock hookMock;
     IERC721ACH.HookType constant BeforeTokenTransfers =
@@ -51,39 +48,29 @@ contract BeforeTokenTransfersHookTest is DSTest {
         _assumeGtZero(startTokenId);
         vm.assume(quantity < 10_000);
         vm.assume(quantity >= startTokenId);
-        _assumeNotBurn(_firstOwner);
-        _assumeNotBurn(_secondOwner);
+        _assumeNotNull(_firstOwner);
+        _assumeNotNull(_secondOwner);
 
         // Mint some tokens first
         erc721Mock.mint(_firstOwner, quantity);
-        _assertNormalTransfer(_firstOwner, _secondOwner, startTokenId);
+        _assertNormalTransfer(
+            address(erc721Mock),
+            _firstOwner,
+            _secondOwner,
+            startTokenId
+        );
 
         // Verify hook override
         test_setBeforeTokenTransfersHook();
-        _assertHookRevert(_secondOwner, _firstOwner, startTokenId);
-    }
-
-    function _assumeNotBurn(address _wallet) internal pure {
-        vm.assume(_wallet != address(0));
-    }
-
-    function _assumeGtZero(uint256 _num) internal pure {
-        vm.assume(_num > 0);
-    }
-
-    function _assertNormalTransfer(
-        address _from,
-        address _to,
-        uint256 _tokenId
-    ) public {
-        vm.prank(_from);
-        erc721Mock.transferFrom(_from, _to, _tokenId);
-
-        _assertOwner(_to, _tokenId);
-    }
-
-    function _assertOwner(address _owner, uint256 _token) internal {
-        assertEq(_owner, erc721Mock.ownerOf(_token));
+        _assertTransferRevert(
+            address(erc721Mock),
+            _secondOwner,
+            _firstOwner,
+            startTokenId,
+            BeforeTokenTransfersHookMock
+                .BeforeTokenTransfersHook_Executed
+                .selector
+        );
     }
 
     function _assertHookRevert(

--- a/test/hooks/BeforeTokenTransfers.t.sol
+++ b/test/hooks/BeforeTokenTransfers.t.sol
@@ -30,12 +30,8 @@ contract BeforeTokenTransfersHookTest is DSTest, HookUtils {
         vm.expectRevert();
         erc721Mock.setHook(BeforeTokenTransfers, address(hookMock));
 
-        vm.prank(DEFAULT_OWNER_ADDRESS);
-        erc721Mock.setHook(BeforeTokenTransfers, address(hookMock));
-        assertEq(
-            address(hookMock),
-            address(erc721Mock.getHook(BeforeTokenTransfers))
-        );
+        // set hook
+        _setHook(address(erc721Mock), BeforeTokenTransfers, address(hookMock));
     }
 
     function test_beforeTokenTransfersHook(
@@ -73,17 +69,25 @@ contract BeforeTokenTransfersHookTest is DSTest, HookUtils {
         );
     }
 
-    function _assertHookRevert(
-        address _from,
-        address _to,
-        uint256 _tokenId
-    ) internal {
-        vm.prank(_from);
-        vm.expectRevert(
-            BeforeTokenTransfersHookMock
-                .BeforeTokenTransfersHook_Executed
-                .selector
+    function test_turn_off_hook(
+        address _firstOwner,
+        address _secondOwner,
+        uint256 startTokenId,
+        uint256 quantity
+    ) public {
+        test_beforeTokenTransfersHook(
+            _firstOwner,
+            _secondOwner,
+            startTokenId,
+            quantity
         );
-        erc721Mock.transferFrom(_from, _to, _tokenId);
+
+        _setHook(address(erc721Mock), BeforeTokenTransfers, address(0));
+        _assertNormalTransfer(
+            address(erc721Mock),
+            _secondOwner,
+            _firstOwner,
+            startTokenId
+        );
     }
 }

--- a/test/hooks/OwnerOfHook.t.sol
+++ b/test/hooks/OwnerOfHook.t.sol
@@ -39,25 +39,39 @@ contract OwnerOfHookTest is DSTest, HookUtils {
         vm.assume(tokenId < 10);
         _assumeNotNull(_buyer);
 
-        test_setOwnerOfHook();
         erc721Mock.mint(_buyer, tokenId);
         _assertOwner(address(erc721Mock), _buyer, tokenId);
 
         // override
-        hookMock.setHooksEnabled(true);
+        test_setOwnerOfHook();
         _assertOwner(address(erc721Mock), address(0), tokenId);
     }
 
-    function test_turn_off_hook(address _buyer, uint256 tokenId) public {
+    function test_ownerOfHook_revert(address _buyer, uint256 tokenId) public {
         test_ownerOfHook(_buyer, tokenId);
-
-        // turn off hook
-        hookMock.setHooksEnabled(false);
-        _assertOwner(address(erc721Mock), _buyer, tokenId);
-
-        // TODO: put this into it's own test
+        // revert
         hookMock.setRevertOwnerOfOverrideHook(true);
         vm.expectRevert(OwnerOfHookMock.OwnerOfHook_Executed.selector);
         erc721Mock.ownerOf(tokenId);
+    }
+
+    function test_turn_off_hook(address _buyer, uint256 tokenId) public {
+        //  test normal override
+        test_ownerOfHook(_buyer, tokenId);
+
+        // turn off hook
+        _turnOffOwnerOfHook();
+        _assertOwner(address(erc721Mock), _buyer, tokenId);
+
+        // test revert override
+        test_ownerOfHook_revert(_buyer, tokenId);
+
+        // turn off hook
+        _turnOffOwnerOfHook();
+        _assertOwner(address(erc721Mock), _buyer, tokenId);
+    }
+
+    function _turnOffOwnerOfHook() internal {
+        _setHook(address(erc721Mock), OwnerOf, address(0));
     }
 }

--- a/test/hooks/OwnerOfHook.t.sol
+++ b/test/hooks/OwnerOfHook.t.sol
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "../utils/ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
 import {OwnerOfHookMock} from "../utils/hooks/OwnerOfHookMock.sol";
 import {IERC721ACH} from "../../src/interfaces/IERC721ACH.sol";
+import {HookUtils} from "../utils/HookUtils.sol";
 
-contract OwnerOfHookTest is DSTest {
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-    address public constant DEFAULT_OWNER_ADDRESS = address(0xC0FFEE);
-    address public constant DEFAULT_BUYER_ADDRESS = address(0xBABE);
+contract OwnerOfHookTest is DSTest, HookUtils {
     ERC721ACHMock erc721Mock;
     OwnerOfHookMock hookMock;
 
@@ -29,26 +26,33 @@ contract OwnerOfHookTest is DSTest {
     function test_setOwnerOfHook() public {
         assertEq(address(0), address(erc721Mock.getHook(OwnerOf)));
 
-        // calling an admin function without being the contract owner should revert       
+        // calling an admin function without being the contract owner should revert
         vm.expectRevert();
         erc721Mock.setHook(OwnerOf, address(hookMock));
-        
-        vm.prank(DEFAULT_OWNER_ADDRESS);
-        erc721Mock.setHook(OwnerOf, address(hookMock));
-        assertEq(address(hookMock), address(erc721Mock.getHook(OwnerOf)));
+
+        // set hook
+        _setHook(address(erc721Mock), OwnerOf, address(hookMock));
     }
 
-    function test_ownerOfHook(uint256 tokenId) public {
+    function test_ownerOfHook(address _buyer, uint256 tokenId) public {
         vm.assume(tokenId > 0);
         vm.assume(tokenId < 10);
+        _assumeNotNull(_buyer);
 
         test_setOwnerOfHook();
-        erc721Mock.mint(DEFAULT_BUYER_ADDRESS, tokenId);
+        erc721Mock.mint(_buyer, tokenId);
+        _assertOwner(address(erc721Mock), _buyer, tokenId);
 
-        assertEq(DEFAULT_BUYER_ADDRESS, erc721Mock.ownerOf(tokenId));
-
+        // override
         hookMock.setHooksEnabled(true);
-        vm.expectRevert(OwnerOfHookMock.OwnerOfHook_Executed.selector);
-        erc721Mock.ownerOf(tokenId);
+        _assertOwner(address(erc721Mock), address(0), tokenId);
+    }
+
+    function test_turn_off_hook(address _buyer, uint256 tokenId) public {
+        test_ownerOfHook(_buyer, tokenId);
+
+        // turn off hook
+        hookMock.setHooksEnabled(false);
+        _assertOwner(address(erc721Mock), _buyer, tokenId);
     }
 }

--- a/test/utils/HookUtils.sol
+++ b/test/utils/HookUtils.sol
@@ -5,7 +5,6 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {ERC721ACHMock} from "./ERC721ACHMock.sol";
 import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
-import {BeforeTokenTransfersHookMock} from "../utils/hooks/BeforeTokenTransfersHookMock.sol";
 import {IERC721ACH} from "../../src/interfaces/IERC721ACH.sol";
 
 contract HookUtils is DSTest {
@@ -52,5 +51,18 @@ contract HookUtils is DSTest {
         vm.prank(_from);
         vm.expectRevert(_err);
         ERC721ACHMock(_target).transferFrom(_from, _to, _tokenId);
+    }
+
+    function _setHook(
+        address _target,
+        IERC721ACH.HookType _type,
+        address _hook
+    ) internal {
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        ERC721ACHMock(_target).setHook(_type, address(_hook));
+        assertEq(
+            address(_hook),
+            address(ERC721ACHMock(_target).getHook(_type))
+        );
     }
 }

--- a/test/utils/HookUtils.sol
+++ b/test/utils/HookUtils.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {DSTest} from "ds-test/test.sol";
+import {ERC721ACHMock} from "./ERC721ACHMock.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {BeforeTokenTransfersHookMock} from "../utils/hooks/BeforeTokenTransfersHookMock.sol";
+import {IERC721ACH} from "../../src/interfaces/IERC721ACH.sol";
+
+contract HookUtils is DSTest {
+    address public constant DEFAULT_OWNER_ADDRESS = address(0xC0FFEE);
+    address public constant DEFAULT_BUYER_ADDRESS = address(0xBABE);
+
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+
+    function _assumeNotNull(address _wallet) internal pure {
+        vm.assume(_wallet != address(0));
+    }
+
+    function _assumeGtZero(uint256 _num) internal pure {
+        vm.assume(_num > 0);
+    }
+
+    function _assertNormalTransfer(
+        address _target,
+        address _from,
+        address _to,
+        uint256 _tokenId
+    ) public {
+        vm.prank(_from);
+        ERC721ACHMock(_target).transferFrom(_from, _to, _tokenId);
+
+        _assertOwner(_target, _to, _tokenId);
+    }
+
+    function _assertOwner(
+        address _target,
+        address _owner,
+        uint256 _token
+    ) internal {
+        assertEq(_owner, ERC721ACHMock(_target).ownerOf(_token));
+    }
+
+    function _assertTransferRevert(
+        address _target,
+        address _from,
+        address _to,
+        uint256 _tokenId,
+        bytes4 _err
+    ) internal {
+        vm.prank(_from);
+        vm.expectRevert(_err);
+        ERC721ACHMock(_target).transferFrom(_from, _to, _tokenId);
+    }
+}

--- a/test/utils/hooks/AfterTokenTransfersHookMock.sol
+++ b/test/utils/hooks/AfterTokenTransfersHookMock.sol
@@ -13,26 +13,14 @@ contract AfterTokenTransfersHookMock is IAfterTokenTransfersHook {
     function setHooksEnabled(bool _enabled) public {
         hooksEnabled = _enabled;
     }
-   
-    /// @notice Check if the AfterTokenTransfers function should use hook.
-    /// @dev Returns whether or not to use the hook for AfterTokenTransfers function
-    function useAfterTokenTransfersHook(
-        address,
-        address,
-        uint256,
-        uint256
-    ) external view override returns (bool) {
-        return hooksEnabled;
-    }
-
 
     /// @notice custom implementation for AfterTokenTransfers Hook.
-    function afterTokenTransfersOverrideHook(
+    function afterTokenTransfersHook(
         address,
         address,
         uint256,
         uint256
-    ) external pure override  {
+    ) external pure override {
         revert AfterTokenTransfersHook_Executed();
     }
 }

--- a/test/utils/hooks/BeforeTokenTransfersHookMock.sol
+++ b/test/utils/hooks/BeforeTokenTransfersHookMock.sol
@@ -7,32 +7,13 @@ contract BeforeTokenTransfersHookMock is IBeforeTokenTransfersHook {
     /// @notice hook was executed
     error BeforeTokenTransfersHook_Executed();
 
-    bool public hooksEnabled;
-
-    /// @notice toggle balanceOf hook.
-    function setHooksEnabled(bool _enabled) public {
-        hooksEnabled = _enabled;
-    }
-   
-    /// @notice Check if the beforeTokenTransfers function should use hook.
-    /// @dev Returns whether or not to use the hook for beforeTokenTransfers function
-    function useBeforeTokenTransfersHook(
-        address,
-        address,
-        uint256,
-        uint256
-    ) external view override returns (bool) {
-        return hooksEnabled;
-    }
-
-
     /// @notice custom implementation for beforeTokenTransfers Hook.
-    function beforeTokenTransfersOverrideHook(
+    function beforeTokenTransfersHook(
         address,
         address,
         uint256,
         uint256
-    ) external pure override  {
+    ) external pure override {
         revert BeforeTokenTransfersHook_Executed();
     }
 }

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -4,9 +4,6 @@ pragma solidity ^0.8.15;
 import {IOwnerOfHook} from "../../../src/interfaces/IOwnerOfHook.sol";
 
 contract OwnerOfHookMock is IOwnerOfHook {
-    /// @notice hook was executed
-    error OwnerOfHook_Executed();
-
     bool public hooksEnabled;
     address public fixedOwner;
 
@@ -27,7 +24,7 @@ contract OwnerOfHookMock is IOwnerOfHook {
     }
 
     /// @notice custom implementation for ownerOf Hook.
-    function ownerOfHook(uint256) external pure override returns (address) {
-        revert OwnerOfHook_Executed();
+    function ownerOfHook(uint256) external view override returns (address) {
+        return fixedOwner;
     }
 }

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -22,16 +22,14 @@ contract OwnerOfHookMock is IOwnerOfHook {
 
     /// @notice Check if the ownerOf function should use hook.
     /// @dev Returns whether or not to use the hook for ownerOf function
-    function useOwnerOfHook(
-        uint256
-    ) external view override returns (bool) {
+    function useOwnerOfHook(uint256) external view override returns (bool) {
         return hooksEnabled;
     }
 
     /// @notice custom implementation for ownerOf Hook.
     function ownerOfOverrideHook(
         uint256
-    ) external view override returns (address) {
+    ) external pure override returns (address) {
         revert OwnerOfHook_Executed();
     }
 }

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -27,9 +27,7 @@ contract OwnerOfHookMock is IOwnerOfHook {
     }
 
     /// @notice custom implementation for ownerOf Hook.
-    function ownerOfOverrideHook(
-        uint256
-    ) external pure override returns (address) {
+    function ownerOfHook(uint256) external pure override returns (address) {
         revert OwnerOfHook_Executed();
     }
 }

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -25,12 +25,6 @@ contract OwnerOfHookMock is IOwnerOfHook {
         fixedOwner = _fixedOwner;
     }
 
-    /// @notice Check if the ownerOf function should use hook.
-    /// @dev Returns whether or not to use the hook for ownerOf function
-    function useOwnerOfHook(uint256) external view override returns (bool) {
-        return hooksEnabled;
-    }
-
     /// @notice custom implementation for ownerOf Hook.
     function ownerOfHook(
         uint256

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -36,6 +36,6 @@ contract OwnerOfHookMock is IOwnerOfHook {
         uint256
     ) external view override returns (address, bool) {
         if (revertOwnerOfOverrideHook) revert OwnerOfHook_Executed();
-        return (fixedOwner, true); // run super
+        return (fixedOwner, false); // run super
     }
 }


### PR DESCRIPTION
# Cleanup before sunday shipment
- update NATSPEC docs
- remove `useXHook` for Transfer Hooks - this logic can be taken care of in external hooks. Keep our hooks simple and light weight.