### PR TITLE
ownerOfHook returns tuple (owner, runSuper)

### DIFF
--- a/src/ERC721ACH.sol
+++ b/src/ERC721ACH.sol
@@ -95,17 +95,25 @@ contract ERC721ACH is ERC721AC, IERC721ACH {
     }
 
     function ownerOf(uint256 tokenId) public view virtual override returns (address) {
-        
+        address owner;
+        bool runSuper;
+
         IOwnerOfHook ownerOfHook = IOwnerOfHook(hooks[HookType.OwnerOf]);
 
         if (
             address(ownerOfHook) != address(0) &&
             ownerOfHook.useOwnerOfHook(tokenId)
         ) {
-            return ownerOfHook.ownerOfOverrideHook(tokenId);
-        } 
+            (owner, runSuper) = ownerOfHook.ownerOfOverrideHook(tokenId);
+        } else {
+            runSuper = true;
+        }
         
-        return super.ownerOf(tokenId);
+        if (runSuper) {
+            owner = super.ownerOf(tokenId);
+        }
+
+        return owner;
     }
 
 

--- a/src/interfaces/IOwnerOfHook.sol
+++ b/src/interfaces/IOwnerOfHook.sol
@@ -27,9 +27,9 @@ interface IOwnerOfHook {
     /**
         @notice Provides a custom implementation for the owner retrieval process.
         @param tokenId The ID of the token whose owner is being retrieved.
-        @return The address of the owner of the token.
+        @return A tuple with The address of the owner of the token and A bool flag whether to run `super.ownerOf` or not
      */
     function ownerOfOverrideHook(
         uint256 tokenId
-    ) external view returns (address);
+    ) external view returns (address, bool);
 }

--- a/test/hooks/OwnerOfHook.t.sol
+++ b/test/hooks/OwnerOfHook.t.sol
@@ -44,10 +44,10 @@ contract OwnerOfHookTest is DSTest {
 
         test_setOwnerOfHook();
         erc721Mock.mint(DEFAULT_BUYER_ADDRESS, tokenId);
-
         assertEq(DEFAULT_BUYER_ADDRESS, erc721Mock.ownerOf(tokenId));
 
         hookMock.setHooksEnabled(true);
+        hookMock.setRevertOwnerOfOverrideHook(true);
         vm.expectRevert(OwnerOfHookMock.OwnerOfHook_Executed.selector);
         erc721Mock.ownerOf(tokenId);
     }

--- a/test/utils/hooks/OwnerOfHookMock.sol
+++ b/test/utils/hooks/OwnerOfHookMock.sol
@@ -7,8 +7,13 @@ contract OwnerOfHookMock is IOwnerOfHook {
     /// @notice hook was executed
     error OwnerOfHook_Executed();
 
+    bool public revertOwnerOfOverrideHook;
     bool public hooksEnabled;
     address public fixedOwner;
+
+    function setRevertOwnerOfOverrideHook(bool _enabled) public {
+        revertOwnerOfOverrideHook = _enabled;
+    }
 
     /// @notice toggle ownerOf hook.
     function setHooksEnabled(bool _enabled) public {
@@ -31,7 +36,8 @@ contract OwnerOfHookMock is IOwnerOfHook {
     /// @notice custom implementation for ownerOf Hook.
     function ownerOfOverrideHook(
         uint256
-    ) external view override returns (address) {
-        revert OwnerOfHook_Executed();
+    ) external view override returns (address, bool) {
+        if (revertOwnerOfOverrideHook) revert OwnerOfHook_Executed();
+        return (address(0), true); // run super
     }
 }


### PR DESCRIPTION
**Refactoring `ownerOf` Function to Utilize OwnerOf Hook**

A version of the `ownerOf` function to effectively utilize the OwnerOf hook. The primary motivation for this change is to improve the conditional execution of `super.ownerOf(tokenId)` based on the return value of the OwnerOf hook.

**Scenario:**

Included a detailed explanation of the scenario where the OwnerOf hook is used to conditionally run `super.ownerOf(tokenId)` based on the validity of the subscription.

**Proposed Code:**

```solidity
  function ownerOf(uint256 tokenId) public view virtual override returns (address) {
      address owner;
      bool runSuper;

      IOwnerOfHook ownerOfHook = IOwnerOfHook(hooks[HookType.OwnerOf]);

      if (
          address(ownerOfHook) != address(0) &&
          ownerOfHook.useOwnerOfHook(tokenId)
      ) {
          (owner, runSuper) = ownerOfHook.ownerOfOverrideHook(tokenId);
      } else {
          runSuper = true;
      }

      if (runSuper) {
          owner = super.ownerOf(tokenId);
      }

      return owner;
  }
```

**OwnerOfHook Implementation:**

```solidity
  function ownerOfOverrideHook(
      uint256 tokenId
  ) external view returns (address, bool) {
      // msg.sender is the ERC721 contract e.g. Cre8ors
      address subscription = ICre8ors(msg.sender).subscription();

      if (subscription == address(0)) {
          return (address(0), true);
      }

      // external call to subscription
      bool isSubscriptionValid =
          ISubscription(subscription).isSubscriptionValid(tokenId);

      if (isSubscriptionValid) {
          return (address(0), true);
      }

      // subscription expired
      // do not run `super.ownerOf(tokenId)`
      return (ownerOfReturns[tokenId], false);
  }
```

**Scenario Explanation:**

The OwnerOf hook acts as a conditional override for the `ownerOf` function. If the subscription is valid, the hook returns the actual `owner`, and the function proceeds without invoking `super.ownerOf(tokenId)`. In contrast, if the subscription is expired or turned off, the hook returns `address(0)`, indicating that there is no owner. In such cases, the function executes `super.ownerOf(tokenId)` to retrieve the owner based on the default implementation.

Please review the proposed code and provide your feedback.
